### PR TITLE
turning off eslint no-inferrable-types config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,7 @@ export default tseslint.config(
     rules: {
       "@typescript-eslint/array-type": "off",
       "@typescript-eslint/consistent-type-definitions": "off",
+      "@typescript-eslint/no-inferrable-types": "off",
       "@typescript-eslint/consistent-type-imports": [
         "warn",
         { prefer: "type-imports", fixStyle: "inline-type-imports" },


### PR DESCRIPTION
### TL;DR

Disabled the TypeScript ESLint rule for inferrable types.

### What changed?

Added `"@typescript-eslint/no-inferrable-types": "off"` to the ESLint configuration file to disable the rule that warns about explicit type annotations for variables or parameters initialized with simple values.

