### PR TITLE
add audio controller layer

### DIFF
--- a/src/app/_components/TestSC.tsx
+++ b/src/app/_components/TestSC.tsx
@@ -1,10 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { SoundCloudAdapter } from "./player/adapters/SoundCloudAdapter";
+import { AudioController } from "./player/AudioController";
+import type { Track } from "./player/types/player";
+
+const testTrack: Track = {
+  title: "Test Track",
+  url: "https://soundcloud.com/evens/evens-year-walk-free-download",
+  source: "soundcloud",
+};
 
 export default function TestPlayer() {
-  const [adapter, setAdapter] = useState<SoundCloudAdapter | null>(null);
+  const [controller, setController] = useState<AudioController | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
 
@@ -25,11 +32,9 @@ export default function TestPlayer() {
 
   const loadTrack = async () => {
     try {
-      const newAdapter = new SoundCloudAdapter("test-player");
-      await newAdapter.loadTrack(
-        "https://soundcloud.com/evens/evens-year-walk-free-download",
-      );
-      setAdapter(newAdapter);
+      const controller = new AudioController();
+      await controller.loadTrack(testTrack);
+      setController(controller);
       setIsLoaded(true);
       console.log("Track loaded successfully!");
     } catch (error) {
@@ -37,19 +42,17 @@ export default function TestPlayer() {
     }
   };
 
-  const play = () => {
-    if (adapter && isLoaded) {
-      adapter.play();
+  const play = async () => {
+    if (controller && isLoaded) {
+      await controller.play();
       setIsPlaying(true);
-      console.log("Play called");
     }
   };
 
-  const pause = () => {
-    if (adapter && isLoaded) {
-      adapter.pause();
+  const pause = async () => {
+    if (controller && isLoaded) {
+      await controller.pause();
       setIsPlaying(false);
-      console.log("Pause called");
     }
   };
 

--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -1,10 +1,68 @@
-"use client";
+import { SoundCloudAdapter } from "./adapters/SoundCloudAdapter";
+import type { MusicPlayerAdapter, Track } from "./types/player";
 
-export function AudioController() {
-  return (
-    <>
-      <button>Play</button>
-      <button>Pause</button>
-    </>
-  );
+export class AudioController {
+  private currentAdapter: MusicPlayerAdapter | null = null;
+  private currentTrack: Track | null = null;
+
+  async loadTrack(track: Track) {
+    switch (track.source) {
+      case "soundcloud":
+        this.currentAdapter = new SoundCloudAdapter();
+        break;
+      default:
+        throw new Error(`Unsupported track source: ${track.source}`);
+    }
+
+    this.currentTrack = track;
+    await this.currentAdapter.loadTrack(track.url);
+  }
+
+  async play() {
+    if (!this.currentAdapter) {
+      console.warn("no adapter, play");
+      return;
+    }
+    this.currentAdapter.play();
+  }
+
+  async pause() {
+    if (!this.currentAdapter) {
+      console.warn("no adapter, pause");
+      return;
+    }
+    this.currentAdapter.pause();
+  }
+
+  async isPlaying() {
+    if (!this.currentAdapter) {
+      console.warn("no adapter, isPlaying");
+      return false;
+    }
+    return await this.currentAdapter.isPlaying();
+  }
+
+  async getCurrentTime() {
+    if (!this.currentAdapter) {
+      console.warn("no adapter, getCurrentTime");
+      return 0;
+    }
+    return await this.currentAdapter.getCurrentTime();
+  }
+
+  seekTo(seconds: number) {
+    if (!this.currentAdapter) {
+      console.warn("no adapter, seekTo");
+      return;
+    }
+    this.currentAdapter.seekTo(seconds);
+  }
+
+  setVolume(value: number) {
+    if (!this.currentAdapter) {
+      console.warn("no adapter, setVolume");
+      return;
+    }
+    this.currentAdapter.setVolume(value);
+  }
 }

--- a/src/app/_components/player/types/player.ts
+++ b/src/app/_components/player/types/player.ts
@@ -2,10 +2,10 @@ export interface MusicPlayerAdapter {
   loadTrack(trackUrl: string): Promise<void>;
   play(): void;
   pause(): void;
-  // isPlaying(): Promise<boolean>;
-  // getCurrentTime(): Promise<number>;
-  // seekTo(seconds: number): void;
-  // setVolume(value: number): void;
+  isPlaying(): Promise<boolean>;
+  getCurrentTime(): Promise<number>;
+  seekTo(seconds: number): void;
+  setVolume(value: number): void;
 }
 
 export interface Track {


### PR DESCRIPTION
### TL;DR

Implemented the AudioController class to manage different music player adapters and updated the test component to use it.

### What changed?

- Transformed `AudioController` from a React component to a class that manages music player adapters
- Implemented methods in `AudioController` for track loading, playback control, and audio settings
- Updated the `MusicPlayerAdapter` interface to include additional methods like `isPlaying()`, `getCurrentTime()`, `seekTo()`, and `setVolume()`
- Modified `TestSC.tsx` to use the new `AudioController` instead of directly using `SoundCloudAdapter`
- Added a `testTrack` object with track metadata to better represent real usage


### Why make this change?

This change introduces a proper abstraction layer between the UI components and the specific audio adapters. The AudioController provides a unified interface for managing different audio sources (currently SoundCloud, but extensible to others), making it easier to add support for additional platforms in the future while keeping the UI components simple and focused on presentation rather than audio implementation details.