### PR TITLE
playlist basic control. next and previous

### DIFF
--- a/src/app/_components/TestSC.tsx
+++ b/src/app/_components/TestSC.tsx
@@ -4,11 +4,18 @@ import { useEffect, useState } from "react";
 import { AudioController } from "./player/AudioController";
 import type { Track } from "./player/types/player";
 
-const testTrack: Track = {
-  title: "Test Track",
-  url: "https://soundcloud.com/evens/evens-year-walk-free-download",
-  source: "soundcloud",
-};
+const testPlaylist: Track[] = [
+  {
+    title: "Test Track 1",
+    url: "https://soundcloud.com/evens/evens-year-walk-free-download",
+    source: "soundcloud",
+  },
+  {
+    title: "Test Track 2",
+    url: "https://soundcloud.com/janu4ryss/dont-want-u-prod-me",
+    source: "soundcloud",
+  },
+];
 
 export default function TestPlayer() {
   const [controller, setController] = useState<AudioController | null>(null);
@@ -30,19 +37,20 @@ export default function TestPlayer() {
     };
   }, []);
 
-  const loadTrack = async () => {
-    try {
-      const controller = new AudioController();
-      await controller.loadTrack(testTrack);
-      setController(controller);
-      setIsLoaded(true);
-      console.log("Track loaded successfully!");
-    } catch (error) {
-      console.error("Failed to load track:", error);
-    }
-  };
-
   const play = async () => {
+    if (!controller) {
+      try {
+        const controller = new AudioController();
+        await controller.loadPlaylist(testPlaylist);
+        setController(controller);
+        setIsLoaded(true);
+        await controller.play();
+        setIsPlaying(true);
+      } catch (error) {
+        console.error("Failed to load playlist:", error);
+      }
+    }
+
     if (controller && isLoaded) {
       await controller.play();
       setIsPlaying(true);
@@ -56,6 +64,18 @@ export default function TestPlayer() {
     }
   };
 
+  const next = async () => {
+    if (controller && isLoaded) {
+      await controller.nextTrack();
+    }
+  };
+
+  const previous = async () => {
+    if (controller && isLoaded) {
+      await controller.previousTrack();
+    }
+  };
+
   return (
     <div className="p-8">
       <h1 className="mb-4 text-2xl font-bold">SoundCloud Adapter Test</h1>
@@ -66,16 +86,8 @@ export default function TestPlayer() {
 
       <div className="space-x-4">
         <button
-          onClick={loadTrack}
-          disabled={isLoaded}
-          className="rounded bg-blue-500 px-4 py-2 text-white disabled:bg-gray-300"
-        >
-          {isLoaded ? "Track Loaded" : "Load Track"}
-        </button>
-
-        <button
           onClick={play}
-          disabled={!isLoaded}
+          disabled={isPlaying}
           className="rounded bg-green-500 px-4 py-2 text-white disabled:bg-gray-300"
         >
           Play
@@ -83,10 +95,26 @@ export default function TestPlayer() {
 
         <button
           onClick={pause}
-          disabled={!isLoaded}
+          disabled={!isLoaded || !isPlaying}
           className="rounded bg-red-500 px-4 py-2 text-white disabled:bg-gray-300"
         >
           Pause
+        </button>
+
+        <button
+          onClick={next}
+          disabled={!isLoaded}
+          className="rounded bg-yellow-500 px-4 py-2 text-white disabled:bg-gray-300"
+        >
+          Next
+        </button>
+
+        <button
+          onClick={previous}
+          disabled={!isLoaded}
+          className="rounded bg-purple-500 px-4 py-2 text-white disabled:bg-gray-300"
+        >
+          Previous
         </button>
       </div>
 

--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -4,20 +4,81 @@ import type { MusicPlayerAdapter, Track } from "./types/player";
 export class AudioController {
   private currentAdapter: MusicPlayerAdapter | null = null;
   private currentTrack: Track | null = null;
+  private playlist: Track[] = [];
+  private currentIndex: number = -1;
 
-  async loadTrack(track: Track) {
-    switch (track.source) {
-      case "soundcloud":
-        this.currentAdapter = new SoundCloudAdapter();
-        break;
-      default:
-        throw new Error(`Unsupported track source: ${track.source}`);
+  private async createAdapterForSource(source: Track["source"]): Promise<void> {
+    // if we don't have a current adapter, or the we're swapping source type, reset the adapter
+    if (this.currentAdapter && this.currentTrack?.source !== source) {
+      this.currentAdapter = null;
     }
 
-    this.currentTrack = track;
-    await this.currentAdapter.loadTrack(track.url);
+    if (!this.currentAdapter) {
+      switch (source) {
+        case "soundcloud":
+          this.currentAdapter = new SoundCloudAdapter();
+          break;
+        default:
+          console.error(`Unsupported track source: ${source}`);
+      }
+    }
   }
 
+  async loadPlaylist(playlist: Track[]) {
+    this.playlist = playlist;
+    this.currentIndex = 0;
+
+    if (this.playlist.length > 0) {
+      await this.createAdapterForSource(this.playlist[0]!.source);
+      await this.loadTrackByIndex(this.currentIndex);
+    }
+  }
+
+  async loadTrack(track: Track) {
+    await this.createAdapterForSource(track.source);
+    await this.currentAdapter!.loadTrack(track.url);
+    this.currentTrack = track;
+  }
+
+  private async loadTrackByIndex(index: number) {
+    if (index < 0 || index >= this.playlist.length) {
+      console.warn("invalid index, loadTrackByIndex");
+      return;
+    }
+
+    const track = this.playlist[index];
+    if (!track) {
+      console.warn("no track, loadTrackByIndex");
+      return;
+    }
+
+    await this.createAdapterForSource(track.source);
+
+    await this.currentAdapter!.loadTrack(track.url);
+    this.currentTrack = track;
+    this.currentIndex = index;
+  }
+
+  // NAVIGATION
+  async nextTrack() {
+    if (!this.canGoNext()) {
+      console.warn("no next track, goNextTrack");
+      return;
+    }
+
+    await this.loadTrackByIndex(this.currentIndex + 1);
+  }
+
+  async previousTrack() {
+    if (!this.canGoPrevious()) {
+      console.warn("no previous track, goPreviousTrack");
+      return;
+    }
+
+    await this.loadTrackByIndex(this.currentIndex - 1);
+  }
+
+  // PLAYBACK
   async play() {
     if (!this.currentAdapter) {
       console.warn("no adapter, play");
@@ -45,7 +106,7 @@ export class AudioController {
   async getCurrentTime() {
     if (!this.currentAdapter) {
       console.warn("no adapter, getCurrentTime");
-      return 0;
+      return -1;
     }
     return await this.currentAdapter.getCurrentTime();
   }
@@ -64,5 +125,26 @@ export class AudioController {
       return;
     }
     this.currentAdapter.setVolume(value);
+  }
+
+  // GETTERS
+  private canGoNext(): boolean {
+    return this.currentIndex < this.playlist.length - 1;
+  }
+
+  private canGoPrevious(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  getCurrentTrack(): Track | null {
+    return this.currentTrack;
+  }
+
+  getCurrentIndex(): number {
+    return this.currentIndex;
+  }
+
+  getPlaylistLength(): number {
+    return this.playlist.length;
   }
 }

--- a/src/app/_components/player/adapters/SoundCloudAdapter.ts
+++ b/src/app/_components/player/adapters/SoundCloudAdapter.ts
@@ -23,23 +23,32 @@ interface SoundCloudWidget {
   setVolume: (value: number) => void;
   bind: (event: string, callback: () => void) => void;
   unbind: (event: string) => void;
+  load: (url: string, options?: { auto_play?: boolean }) => void;
 }
 
 export class SoundCloudAdapter implements MusicPlayerAdapter {
   private player: SoundCloudWidget | null = null;
   private iframeId: string;
-  private currentUrl: string = "";
   private isReady: boolean = false;
-  private readyPromise: Promise<void> | null = null;
+  private isInitialized: boolean = false;
 
   constructor(iframeId: string = "soundcloud-player") {
     this.iframeId = iframeId;
   }
 
   async loadTrack(trackUrl: string): Promise<void> {
-    this.currentUrl = trackUrl;
     this.isReady = false;
 
+    if (!this.isInitialized) {
+      // First time, create the widget
+      await this.initializeWidget(trackUrl);
+    } else {
+      // Subsequent loads
+      await this.loadNewTrack(trackUrl);
+    }
+  }
+
+  private async initializeWidget(trackUrl: string): Promise<void> {
     const iframe = this.getOrCreateIframe();
     const encodedUrl = encodeURIComponent(trackUrl);
     const scUrl = `https://w.soundcloud.com/player/?url=${encodedUrl}`;
@@ -58,6 +67,7 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
 
         this.player.bind(window.SC.Widget.Events.READY, () => {
           this.isReady = true;
+          this.isInitialized = true;
           resolve();
         });
 
@@ -69,6 +79,24 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
       iframe.onerror = () => {
         console.warn("Failed to load SoundCloud iframe");
       };
+    });
+  }
+
+  private async loadNewTrack(trackUrl: string): Promise<void> {
+    this.isReady = false;
+    if (!this.player) {
+      console.warn("Player not initialized");
+      return;
+    }
+
+    return new Promise((resolve) => {
+      this.player!.bind(window.SC.Widget.Events.READY, () => {
+        this.isReady = true;
+        this.player!.unbind(window.SC.Widget.Events.READY);
+        resolve();
+      });
+
+      this.player!.load(trackUrl, { auto_play: true });
     });
   }
 


### PR DESCRIPTION
### TL;DR

Enhanced the audio player with playlist functionality, including next/previous track navigation.

### What changed?

- Replaced single track implementation with a playlist array in `TestSC.tsx`
- Added playlist management to `AudioController` with methods for:
  - Loading a playlist
  - Navigating between tracks (next/previous)
  - Getting current track information
- Updated the SoundCloud adapter to handle loading new tracks without recreating the widget
- Added UI controls for next/previous track navigation
- Improved the player interface by removing the separate "Load Track" button

### How to test?

1. Open the SoundCloud Adapter Test page
2. Click "Play" to start the playlist
3. Use the "Next" and "Previous" buttons to navigate between tracks
4. Verify that the player correctly loads and plays different tracks
5. Check that the player state (playing/paused) is maintained when switching tracks

### Why make this change?

This change improves the user experience by allowing playback of multiple tracks in sequence without manual reloading. It also establishes a foundation for more advanced playlist features while maintaining a clean separation between the UI, controller, and adapter layers.