### PR TITLE
db update for clarity and multiple artists per track

### DIFF
--- a/prisma/migrations/20250821045532_db_reordering_clarifying_and_multiple_artists/migration.sql
+++ b/prisma/migrations/20250821045532_db_reordering_clarifying_and_multiple_artists/migration.sql
@@ -1,0 +1,87 @@
+/*
+  Warnings:
+
+  - You are about to drop the `PlaylistTrack` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `UserTrackMetadata` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."PlaylistTrack" DROP CONSTRAINT "PlaylistTrack_playlistId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."PlaylistTrack" DROP CONSTRAINT "PlaylistTrack_trackId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."UserTrackMetadata" DROP CONSTRAINT "UserTrackMetadata_albumId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."UserTrackMetadata" DROP CONSTRAINT "UserTrackMetadata_artistId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."UserTrackMetadata" DROP CONSTRAINT "UserTrackMetadata_trackId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."UserTrackMetadata" DROP CONSTRAINT "UserTrackMetadata_userId_fkey";
+
+-- DropTable
+DROP TABLE "public"."PlaylistTrack";
+
+-- DropTable
+DROP TABLE "public"."UserTrackMetadata";
+
+-- CreateTable
+CREATE TABLE "public"."PlaylistEntry" (
+    "position" INTEGER NOT NULL,
+    "playlistId" INTEGER NOT NULL,
+    "libraryTrackId" INTEGER NOT NULL,
+
+    CONSTRAINT "PlaylistEntry_pkey" PRIMARY KEY ("playlistId","libraryTrackId")
+);
+
+-- CreateTable
+CREATE TABLE "public"."LibraryTrack" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "title" TEXT NOT NULL,
+    "albumId" INTEGER,
+    "trackId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "LibraryTrack_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."LibraryTrackArtist" (
+    "libraryTrackId" INTEGER NOT NULL,
+    "artistId" INTEGER NOT NULL,
+
+    CONSTRAINT "LibraryTrackArtist_pkey" PRIMARY KEY ("libraryTrackId","artistId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlaylistEntry_playlistId_position_key" ON "public"."PlaylistEntry"("playlistId", "position");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LibraryTrack_trackId_userId_key" ON "public"."LibraryTrack"("trackId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "public"."PlaylistEntry" ADD CONSTRAINT "PlaylistEntry_playlistId_fkey" FOREIGN KEY ("playlistId") REFERENCES "public"."Playlist"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PlaylistEntry" ADD CONSTRAINT "PlaylistEntry_libraryTrackId_fkey" FOREIGN KEY ("libraryTrackId") REFERENCES "public"."LibraryTrack"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."LibraryTrack" ADD CONSTRAINT "LibraryTrack_albumId_fkey" FOREIGN KEY ("albumId") REFERENCES "public"."Album"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."LibraryTrack" ADD CONSTRAINT "LibraryTrack_trackId_fkey" FOREIGN KEY ("trackId") REFERENCES "public"."Track"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."LibraryTrack" ADD CONSTRAINT "LibraryTrack_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."LibraryTrackArtist" ADD CONSTRAINT "LibraryTrackArtist_libraryTrackId_fkey" FOREIGN KEY ("libraryTrackId") REFERENCES "public"."LibraryTrack"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."LibraryTrackArtist" ADD CONSTRAINT "LibraryTrackArtist_artistId_fkey" FOREIGN KEY ("artistId") REFERENCES "public"."Artist"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,9 +25,10 @@ model User {
     updatedAt DateTime @updatedAt
 
     playlists         Playlist[]
-    userTrackMetadata  UserTrackMetadata[]
+    libraryTracks     LibraryTrack[]
 }
 
+// belongs to a user and contains ordered entries of library tracks
 model Playlist {
     id        Int      @id @default(autoincrement())
     createdAt DateTime @default(now())
@@ -37,7 +38,7 @@ model Playlist {
 
     userId          Int
     user            User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-    playlistTracks  PlaylistTrack[]
+    playlistEntries  PlaylistEntry[]
 }
 
 enum SongSource {
@@ -47,6 +48,8 @@ enum SongSource {
     local
 }
 
+// a track represents a unique audio item from a source (e.g. soundcloud, spotify, etc..)
+// it is not user specific. each user may have their own library track pointing here that holds THEIR metadata
 model Track {
     id        Int      @id @default(autoincrement())
     createdAt DateTime @default(now())
@@ -56,33 +59,23 @@ model Track {
     source             SongSource
     sourceIdentifier   String
 
-    playlistTracks     PlaylistTrack[]
-    userTrackMetadata   UserTrackMetadata[]
+    libraryTracks   LibraryTrack[]
 
     @@unique ([source, sourceIdentifier])
 }
 
-model PlaylistTrack {
+// join table for each entry in a playlist, position enforces order for display
+model PlaylistEntry {
     position    Int
 
     playlistId  Int
-    playlist    Playlist @relation(fields: [playlistId], references: [id])
+    playlist    Playlist @relation(fields: [playlistId], references: [id], onDelete: Cascade)
 
-    trackId      Int
-    track        Track     @relation(fields: [trackId], references: [id], onDelete: Cascade)
+    libraryTrackId      Int
+    libraryTrack        LibraryTrack     @relation(fields: [libraryTrackId], references: [id], onDelete: Cascade)
 
-    @@id([playlistId, trackId])
+    @@id([playlistId, libraryTrackId])
     @@unique ([playlistId, position])
-}
-
-model Artist {
-    id        Int      @id @default(autoincrement())
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
-
-    name      String
-
-    userTrackMetadata UserTrackMetadata[]
 }
 
 model Album {
@@ -92,18 +85,27 @@ model Album {
 
     name      String
 
-    userTrackMetadata UserTrackMetadata[]
+    libraryTracks LibraryTrack[]
+}
+model Artist {
+    id        Int      @id @default(autoincrement())
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    name      String
+
+    libraryTracks LibraryTrackArtist[]
 }
 
-model UserTrackMetadata {
+// a library track is a user's personal copy of a track
+// this lets different users have the same track in their library but with different metadata
+model LibraryTrack {
     id        Int      @id @default(autoincrement())
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 
     title     String
 
-    artistId  Int?
-    artist    Artist?   @relation(fields: [artistId], references: [id], onDelete: SetNull)
     albumId   Int?
     album     Album?    @relation(fields:[albumId], references: [id], onDelete: SetNull)
     trackId   Int
@@ -111,5 +113,19 @@ model UserTrackMetadata {
     userId    Int
     user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+    playlistEntries PlaylistEntry[]
+    artists         LibraryTrackArtist[]
+
     @@unique ([trackId, userId])
+}
+
+// join table for each artist in a library track, allows for multiple artists per library track
+model LibraryTrackArtist {
+    libraryTrackId Int
+    libraryTrack   LibraryTrack @relation(fields: [libraryTrackId], references: [id], onDelete: Cascade)
+
+    artistId Int
+    artist   Artist @relation(fields: [artistId], references: [id], onDelete: Cascade)
+
+    @@id([libraryTrackId, artistId])
 }


### PR DESCRIPTION
### TL;DR

Restructured database schema to support multiple artists per track and clarified relationships between tracks, playlists, and user libraries. Some semantic name changes to table names and adding comments for future reasoning. 

### What changed?

- Renamed `PlaylistTrack` to `PlaylistEntry` with improved position tracking
- Replaced `UserTrackMetadata` with `LibraryTrack` to better represent user-specific track data
- Added `LibraryTrackArtist` join table to support multiple artists per track
- Updated foreign key relationships to ensure proper cascading deletions
- Added clarifying comments to the schema to explain entity relationships


### Why make this change?

The previous schema didn't support multiple artists per track and had unclear relationships between entities. This restructuring provides a more accurate representation of music library concepts, where:
- A track can have multiple artists
- Users have their own library of tracks with personalized metadata
- Playlists contain ordered entries from a user's library
- Relationships between entities are more clearly defined with appropriate cascade behaviors

