### PR TITLE
clean up of components and rework to sc adapter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["autoincrement", "soundcloud"]
+  "cSpell.words": ["autoincrement", "soundcloud", "streamable"]
 }

--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -1,5 +1,9 @@
 import { SoundCloudAdapter } from "./adapters/SoundCloudAdapter";
-import type { MusicPlayerAdapter, Track } from "./types/player";
+import type {
+  MusicPlayerAdapter,
+  Track,
+  SoundCloudSound,
+} from "./types/player";
 
 export class AudioController {
   private currentAdapter: MusicPlayerAdapter | null = null;
@@ -148,11 +152,19 @@ export class AudioController {
     return this.playlist.length;
   }
 
-  async getDuration(): Promise<number> {
+  get duration(): number {
     if (!this.currentAdapter) {
       console.warn("no adapter, getDuration");
       return 0;
     }
-    return await this.currentAdapter.getDuration();
+    return this.currentAdapter.duration;
+  }
+
+  get sound(): SoundCloudSound | null {
+    if (!this.currentAdapter) {
+      console.warn("no adapter, getSound");
+      return null;
+    }
+    return this.currentAdapter.sound;
   }
 }

--- a/src/app/_components/player/MusicPlayer.tsx
+++ b/src/app/_components/player/MusicPlayer.tsx
@@ -1,209 +1,44 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { AudioController } from "./AudioController";
-import type { Track } from "./types/player";
-import { Slider } from "~/components/ui/slider";
-import { Button } from "~/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "~/components/ui/popover";
-import { Play, Pause, SkipForward, SkipBack, Volume2 } from "lucide-react";
-import { formatTime } from "./utils";
+import { useMusicPlayer } from "./useMusicPlayer";
+import { ProgressBar } from "./components/ProgressBar";
+import { PlaybackControl } from "./components/PlaybackControl";
+import { VolumeControl } from "./components/VolumeControl";
 
-const testPlaylist: Track[] = [
-  {
-    title: "Test Track 1",
-    url: "https://soundcloud.com/evens/evens-year-walk-free-download",
-    source: "soundcloud",
-  },
-  {
-    title: "Test Track 2",
-    url: "https://soundcloud.com/janu4ryss/dont-want-u-prod-me",
-    source: "soundcloud",
-  },
-];
-
-export default function MusicPlayer() {
-  const [controller, setController] = useState<AudioController | null>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [volume, setVolume] = useState(100);
-  const [duration, setDuration] = useState(0);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [isSeeking, setIsSeeking] = useState(false);
-
-  useEffect(() => {
-    // Load SoundCloud API script
-    const script = document.createElement("script");
-    script.src = "https://w.soundcloud.com/player/api.js";
-    script.async = true;
-    script.onload = () => {
-      console.log("SoundCloud API loaded");
-    };
-    document.head.appendChild(script);
-
-    return () => {
-      document.head.removeChild(script);
-    };
-  }, []);
-
-  const updateDuration = async () => {
-    if (controller && isLoaded) {
-      const duration = await controller.getDuration();
-      setDuration(duration);
-    }
-  };
-
-  useEffect(() => {
-    void updateDuration();
-  }, [controller, isLoaded, updateDuration]);
-
-  useEffect(() => {
-    let interval: NodeJS.Timeout;
-
-    if (isPlaying && controller && isLoaded) {
-      interval = setInterval(() => {
-        if (!isSeeking) {
-          void controller.getCurrentTime().then((time) => {
-            setCurrentTime(time);
-          });
-        }
-      }, 1000);
-    }
-
-    return () => {
-      if (interval) {
-        clearInterval(interval);
-      }
-    };
-  }, [isPlaying, controller, isLoaded, isSeeking]);
-
-  const play = async () => {
-    if (!controller) {
-      try {
-        const controller = new AudioController();
-        await controller.loadPlaylist(testPlaylist);
-        setController(controller);
-        setIsLoaded(true);
-        await controller.play();
-        setIsPlaying(true);
-      } catch (error) {
-        console.error("Failed to load playlist:", error);
-      }
-    }
-
-    if (controller && isLoaded) {
-      await controller.play();
-      setIsPlaying(true);
-    }
-  };
-
-  const pause = async () => {
-    if (controller && isLoaded) {
-      await controller.pause();
-      setIsPlaying(false);
-    }
-  };
-
-  const next = async () => {
-    if (controller && isLoaded) {
-      await controller.nextTrack();
-      void updateDuration();
-    }
-  };
-
-  const previous = async () => {
-    if (controller && isLoaded) {
-      await controller.previousTrack();
-      void updateDuration();
-    }
-  };
-
-  const handleVolumeChange = (volume: number[]) => {
-    if (controller && isLoaded && volume[0]) {
-      controller.setVolume(volume[0]);
-      setVolume(volume[0]);
-    }
-  };
-
-  const handleProgressChange = (value: number[]) => {
-    if (controller && isLoaded && value[0] !== undefined) {
-      setIsSeeking(true);
-      setCurrentTime(value[0]);
-    }
-  };
-
-  const handleProgressCommit = (value: number[]) => {
-    if (controller && isLoaded && value[0] !== undefined) {
-      controller.seekTo(value[0] * 1000);
-      setIsSeeking(false);
-    }
-  };
+export const MusicPlayer = () => {
+  const {
+    isPlaying,
+    volume,
+    duration,
+    currentTime,
+    play,
+    pause,
+    next,
+    previous,
+    handleVolumeChange,
+    handleProgressChange,
+    handleProgressCommit,
+  } = useMusicPlayer();
 
   return (
-    <div className="fixed bottom-10 left-1/2 -translate-x-1/2">
+    <div className="fixed bottom-10 left-1/2 z-100 flex -translate-x-1/2 gap-4">
       <div id="player-container" className="mb-4">
         {/* Iframe will be inserted here */}
       </div>
-
-      <div className="flex items-baseline space-x-4">
-        <Button
-          onClick={previous}
-          className="px-4 py-2 text-white disabled:bg-gray-300"
-        >
-          <SkipBack className="h-4 w-4" />
-        </Button>
-
-        <Button
-          onClick={isPlaying ? pause : play}
-          className="bg-green-500 disabled:bg-gray-300"
-        >
-          {isPlaying ? (
-            <Pause className="h-4 w-4" />
-          ) : (
-            <Play className="h-4 w-4" />
-          )}
-        </Button>
-
-        <Button
-          onClick={next}
-          className="px-4 py-2 text-white disabled:bg-gray-300"
-        >
-          <SkipForward className="h-4 w-4" />
-        </Button>
-
-        <Slider
-          value={[currentTime]}
-          onValueChange={handleProgressChange}
-          onValueCommit={handleProgressCommit}
-          max={duration}
-          step={1}
-          className="w-100"
-        />
-
-        <span className="w-24">
-          {formatTime(currentTime)} / {formatTime(duration)}
-        </span>
-
-        <Popover>
-          <PopoverTrigger>
-            <Volume2 className="h-4 w-4 bg-black text-white" />
-          </PopoverTrigger>
-          <PopoverContent side="top" className="w-fit">
-            <Slider
-              value={[volume]}
-              onValueChange={handleVolumeChange}
-              max={100}
-              step={1}
-              orientation="vertical"
-              className="w-fit"
-            />
-          </PopoverContent>
-        </Popover>
-      </div>
+      <PlaybackControl
+        isPlaying={isPlaying}
+        onPlay={play}
+        onPause={pause}
+        onNext={next}
+        onPrevious={previous}
+      />
+      <ProgressBar
+        currentTime={currentTime}
+        duration={duration}
+        onProgressChange={handleProgressChange}
+        onProgressCommit={handleProgressCommit}
+      />
+      <VolumeControl volume={volume} onVolumeChange={handleVolumeChange} />
     </div>
   );
-}
+};

--- a/src/app/_components/player/adapters/SoundCloudAdapter.ts
+++ b/src/app/_components/player/adapters/SoundCloudAdapter.ts
@@ -1,4 +1,4 @@
-import type { MusicPlayerAdapter } from "../types/player";
+import type { MusicPlayerAdapter, SoundCloudSound } from "../types/player";
 
 declare global {
   interface Window {
@@ -8,6 +8,7 @@ declare global {
         Events: {
           READY: string;
           ERROR: string;
+          LOAD_PROGRESS: number;
         };
       };
     };
@@ -23,8 +24,12 @@ interface SoundCloudWidget {
   setVolume: (value: number) => void;
   bind: (event: string, callback: () => void) => void;
   unbind: (event: string) => void;
-  load: (url: string, options?: { auto_play?: boolean }) => void;
+  load: (
+    url: string,
+    options?: { auto_play?: boolean; callback?: () => void },
+  ) => void;
   getDuration: (callback: (duration: number) => void) => void;
+  getCurrentSound: (callback: (sound: SoundCloudSound) => void) => void;
 }
 
 export class SoundCloudAdapter implements MusicPlayerAdapter {
@@ -32,6 +37,7 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
   private iframeId: string;
   private isReady: boolean = false;
   private isInitialized: boolean = false;
+  private currentSound: SoundCloudSound | null = null;
 
   constructor(iframeId: string = "soundcloud-player") {
     this.iframeId = iframeId;
@@ -47,6 +53,21 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
       // Subsequent loads
       await this.loadNewTrack(trackUrl);
     }
+  }
+
+  private async waitForValidSound(): Promise<SoundCloudSound> {
+    return new Promise((resolve) => {
+      const checkSound = () => {
+        this.player!.getCurrentSound((sound: SoundCloudSound) => {
+          if (sound && sound.full_duration > 0) {
+            resolve(sound);
+          } else {
+            setTimeout(checkSound, 100);
+          }
+        });
+      };
+      checkSound();
+    });
   }
 
   private async initializeWidget(trackUrl: string): Promise<void> {
@@ -67,9 +88,17 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
         }
 
         this.player.bind(window.SC.Widget.Events.READY, () => {
-          this.isReady = true;
-          this.isInitialized = true;
-          resolve();
+          this.waitForValidSound()
+            .then((sound) => {
+              this.currentSound = sound;
+              this.isReady = true;
+              this.isInitialized = true;
+              resolve();
+            })
+            .catch((error) => {
+              console.warn("Failed to wait for valid sound:", error);
+              resolve();
+            });
         });
 
         this.player.bind(window.SC.Widget.Events.ERROR, (error?: string) => {
@@ -91,13 +120,21 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
     }
 
     return new Promise((resolve) => {
-      this.player!.bind(window.SC.Widget.Events.READY, () => {
-        this.isReady = true;
-        this.player!.unbind(window.SC.Widget.Events.READY);
-        resolve();
+      this.player!.load(trackUrl, {
+        auto_play: true,
+        callback: () => {
+          this.waitForValidSound()
+            .then((sound) => {
+              this.currentSound = sound;
+              this.isReady = true;
+              resolve();
+            })
+            .catch((error) => {
+              console.warn("Failed to wait for valid sound:", error);
+              resolve();
+            });
+        },
       });
-
-      this.player!.load(trackUrl, { auto_play: true });
     });
   }
 
@@ -171,17 +208,15 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
     this.player.setVolume(value);
   }
 
-  async getDuration(): Promise<number> {
-    if (!this.player || !this.isReady) {
-      console.warn("SoundCloud player not ready for getDuration");
+  get duration(): number {
+    if (!this.currentSound) {
       return 0;
     }
+    return this.currentSound.full_duration / 1000;
+  }
 
-    return new Promise((resolve) => {
-      this.player!.getDuration((duration: number) => {
-        resolve(duration / 1000);
-      });
-    });
+  get sound(): SoundCloudSound | null {
+    return this.currentSound;
   }
 
   private getOrCreateIframe(): HTMLIFrameElement {

--- a/src/app/_components/player/components/PlaybackControl.tsx
+++ b/src/app/_components/player/components/PlaybackControl.tsx
@@ -1,0 +1,47 @@
+import { Button } from "~/components/ui/button";
+import { Play, Pause, SkipForward, SkipBack } from "lucide-react";
+
+interface PlaybackControlProps {
+  isPlaying: boolean;
+  onPlay: () => void;
+  onPause: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
+}
+
+export const PlaybackControl = ({
+  isPlaying,
+  onPlay,
+  onPause,
+  onNext,
+  onPrevious,
+}: PlaybackControlProps) => {
+  return (
+    <div className="flex flex-row gap-2">
+      <Button
+        onClick={onPrevious}
+        className="px-4 py-2 text-white disabled:bg-gray-300"
+      >
+        <SkipBack className="h-4 w-4" />
+      </Button>
+
+      <Button
+        onClick={isPlaying ? onPause : onPlay}
+        className="bg-green-500 disabled:bg-gray-300"
+      >
+        {isPlaying ? (
+          <Pause className="h-4 w-4" />
+        ) : (
+          <Play className="h-4 w-4" />
+        )}
+      </Button>
+
+      <Button
+        onClick={onNext}
+        className="px-4 py-2 text-white disabled:bg-gray-300"
+      >
+        <SkipForward className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+};

--- a/src/app/_components/player/components/ProgressBar.tsx
+++ b/src/app/_components/player/components/ProgressBar.tsx
@@ -1,0 +1,33 @@
+import { Slider } from "~/components/ui/slider";
+import { formatTime } from "../utils";
+
+interface ProgressBarProps {
+  currentTime: number;
+  duration: number;
+  onProgressChange: (value: number[]) => void;
+  onProgressCommit: (value: number[]) => void;
+}
+
+export const ProgressBar = ({
+  currentTime,
+  duration,
+  onProgressChange,
+  onProgressCommit,
+}: ProgressBarProps) => {
+  return (
+    <>
+      <Slider
+        value={[currentTime]}
+        onValueChange={onProgressChange}
+        onValueCommit={onProgressCommit}
+        max={duration}
+        step={1}
+        className="w-100"
+      />
+
+      <span className="w-24">
+        {formatTime(currentTime)} / {formatTime(duration)}
+      </span>
+    </>
+  );
+};

--- a/src/app/_components/player/components/VolumeControl.tsx
+++ b/src/app/_components/player/components/VolumeControl.tsx
@@ -1,0 +1,38 @@
+import { Button } from "~/components/ui/button";
+import { Slider } from "~/components/ui/slider";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+import { Volume2 } from "lucide-react";
+
+interface VolumeControlProps {
+  volume: number;
+  onVolumeChange: (value: number[]) => void;
+}
+
+export const VolumeControl = ({
+  volume,
+  onVolumeChange,
+}: VolumeControlProps) => {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="sm">
+          <Volume2 className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent side="top" className="w-fit">
+        <Slider
+          value={[volume]}
+          onValueChange={onVolumeChange}
+          max={100}
+          step={1}
+          orientation="vertical"
+          className="w-fit"
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/app/_components/player/types/player.ts
+++ b/src/app/_components/player/types/player.ts
@@ -6,7 +6,22 @@ export interface MusicPlayerAdapter {
   getCurrentTime(): Promise<number>;
   seekTo(seconds: number): void;
   setVolume(value: number): void;
-  getDuration(): Promise<number>;
+  readonly duration: number;
+  readonly sound: SoundCloudSound | null;
+}
+
+export interface SoundCloudSound {
+  artwork_url: string;
+  full_duration: number; //in ms
+  permalink_url: string;
+  id: number;
+  title: string;
+  streamable: boolean;
+  user: {
+    avatar_url: string;
+    username: string;
+  };
+  waveform_url: string;
 }
 
 export interface Track {
@@ -15,6 +30,6 @@ export interface Track {
   // artist?: string;
   url: string;
   source: "spotify" | "soundcloud" | "youtube" | "local";
-  // duration?: number;
+  duration?: number;
   // artwork?: string;
 }

--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -1,0 +1,161 @@
+import { useEffect, useState, useCallback } from "react";
+import { AudioController } from "./AudioController";
+import type { Track } from "./types/player";
+
+const testPlaylist: Track[] = [
+  {
+    title: "year walk",
+    url: "https://soundcloud.com/evens/evens-year-walk-free-download",
+    source: "soundcloud",
+    // duration: 120,
+  },
+  {
+    title: "dont want",
+    url: "https://soundcloud.com/janu4ryss/dont-want-u-prod-me",
+    source: "soundcloud",
+    // duration: 180,
+  },
+];
+
+export function useMusicPlayer() {
+  const [controller, setController] = useState<AudioController | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [volume, setVolume] = useState(100);
+  const [duration, setDuration] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [isSeeking, setIsSeeking] = useState(false);
+
+  // load soundcloud script
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://w.soundcloud.com/player/api.js";
+    script.async = true;
+    script.onload = () => {
+      console.log("SoundCloud API loaded");
+    };
+    document.head.appendChild(script);
+
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, []);
+
+  // timer to update current time
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+
+    if (isPlaying && controller && isLoaded) {
+      interval = setInterval(() => {
+        if (!isSeeking) {
+          void controller.getCurrentTime().then((time) => {
+            setCurrentTime(time);
+          });
+        }
+      }, 500);
+    }
+
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+  }, [isPlaying, controller, isLoaded, isSeeking]);
+
+  const play = useCallback(async () => {
+    if (!controller) {
+      try {
+        const controller = new AudioController();
+        await controller.loadPlaylist(testPlaylist);
+        setController(controller);
+        setIsLoaded(true);
+        await controller.play();
+        controller.setVolume(volume);
+        setDuration(controller.duration);
+        setIsPlaying(true);
+      } catch (error) {
+        console.error("Failed to load playlist:", error);
+      }
+    }
+
+    if (controller && isLoaded) {
+      await controller.play();
+      setIsPlaying(true);
+    }
+  }, [controller, isLoaded, volume]);
+
+  const pause = useCallback(async () => {
+    if (controller && isLoaded) {
+      await controller.pause();
+      setIsPlaying(false);
+    }
+  }, [controller, isLoaded]);
+
+  const next = useCallback(async () => {
+    if (controller && isLoaded) {
+      // hacky loading state to get the slider and duration to properly display while loading next track
+      setCurrentTime(0.01);
+      setDuration(0.9);
+      await controller.nextTrack();
+      controller.setVolume(volume);
+      setDuration(controller.duration);
+    }
+  }, [controller, isLoaded, volume]);
+
+  const previous = useCallback(async () => {
+    if (controller && isLoaded) {
+      setCurrentTime(0.01);
+      setDuration(0.9);
+      await controller.previousTrack();
+      controller.setVolume(volume);
+      setDuration(controller.duration);
+    }
+  }, [controller, isLoaded, volume]);
+
+  const handleVolumeChange = useCallback(
+    (volume: number[]) => {
+      if (volume[0] !== undefined) {
+        setVolume(volume[0]);
+
+        if (controller && isLoaded) {
+          controller.setVolume(volume[0]);
+        }
+      }
+    },
+    [controller, isLoaded],
+  );
+
+  const handleProgressChange = useCallback(
+    (value: number[]) => {
+      if (controller && isLoaded && value[0] !== undefined) {
+        setIsSeeking(true);
+        setCurrentTime(value[0]);
+      }
+    },
+    [controller, isLoaded],
+  );
+
+  const handleProgressCommit = useCallback(
+    (value: number[]) => {
+      if (controller && isLoaded && value[0] !== undefined) {
+        controller.seekTo(value[0] * 1000);
+        setIsSeeking(false);
+      }
+    },
+    [controller, isLoaded],
+  );
+
+  return {
+    isPlaying,
+    volume,
+    duration,
+    currentTime,
+    play,
+    pause,
+    next,
+    previous,
+    handleVolumeChange,
+    handleProgressChange,
+    handleProgressCommit,
+  };
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { type Metadata } from "next";
 import { Geist } from "next/font/google";
 
 import { TRPCReactProvider } from "~/trpc/react";
-import MusicPlayer from "~/app/_components/player/MusicPlayer";
+import { MusicPlayer } from "~/app/_components/player/MusicPlayer";
 
 export const metadata: Metadata = {
   title: "Aggregate",

--- a/src/app/playlist/[id]/page.tsx
+++ b/src/app/playlist/[id]/page.tsx
@@ -1,12 +1,11 @@
 import { api } from "~/trpc/server";
 
-const Playlist = async ({ params }: { params: { id: string } }) => {
+const Playlist = async ({ params }: { params: Promise<{ id: string }> }) => {
+  const { id: playlistId } = await params;
   const playlist = await api.playlists.getById({
-    id: parseInt(params.id),
+    id: parseInt(playlistId),
   });
   const songs = playlist?.playlistEntries;
-
-  console.log(playlist, "+++++");
 
   return (
     <>


### PR DESCRIPTION
### TL;DR

Large PR, should've been split up. The main things achieved:
- finally split the 'MusicPlayer' component into smaller ui parts
- separated the player logic out of the component and into a hook 
- fixed duration calculation for the soundcloud adapter
- added the 'sound' property to access more metadata about the track should it be needed later on

### What changed?

- Split the monolithic `MusicPlayer` component into smaller, reusable components:
  - `PlaybackControl` - handles play/pause and track navigation
  - `ProgressBar` - displays and controls playback progress
  - `VolumeControl` - manages volume settings
- Created a custom `useMusicPlayer` hook to handle player state and logic
- Enhanced the `SoundCloudAdapter` to properly handle track metadata and duration
- Added support for retrieving the current sound object from SoundCloud
- Improved track loading with better error handling and state management
- Fixed duration calculation to use the sound's full_duration property


