### PR TITLE
common ux expectation of previous track

### DIFF
--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -104,13 +104,21 @@ export function useMusicPlayer() {
 
   const previous = useCallback(async () => {
     if (controller && isLoaded) {
+      // user expectation, if into the song, hitting previous should go back to the start
+      // if at the start, go previous track
+      if (currentTime > 3) {
+        controller.seekTo(0);
+        setCurrentTime(0);
+        return;
+      }
+
       setCurrentTime(0.01);
       setDuration(0.9);
       await controller.previousTrack();
       controller.setVolume(volume);
       setDuration(controller.duration);
     }
-  }, [controller, isLoaded, volume]);
+  }, [controller, isLoaded, volume, currentTime]);
 
   const handleVolumeChange = useCallback(
     (volume: number[]) => {


### PR DESCRIPTION
### TL;DR

Added behavior to the previous button to restart the current track if the user is more than 3 seconds into it.

### What changed?

Modified the `previous` function in `useMusicPlayer.ts` to check if the current playback time is greater than 3 seconds. If it is, the function now resets the current track to the beginning instead of immediately going to the previous track. 


### Why make this change?

This change aligns with common music player behavior where pressing the previous button first resets the current track if you're already into it, matching user expectations. This is the standard behavior in most music applications like Spotify, Apple Music, etc., providing a more intuitive user experience.