### PR TITLE
adding autoplay next song to music player

### DIFF
--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -10,6 +10,7 @@ export class AudioController {
   private currentTrack: Track | null = null;
   private playlist: Track[] = [];
   private currentIndex: number = -1;
+  private onTrackEndCallback: (() => void) | null = null;
 
   private async createAdapterForSource(source: Track["source"]): Promise<void> {
     // if we don't have a current adapter, or the we're swapping source type, reset the adapter
@@ -21,6 +22,10 @@ export class AudioController {
       switch (source) {
         case "soundcloud":
           this.currentAdapter = new SoundCloudAdapter();
+          this.currentAdapter.onTrackEnd(() => {
+            console.log("track end");
+            void this.handleTrackEnd();
+          });
           break;
         default:
           console.error(`Unsupported track source: ${source}`);
@@ -61,6 +66,10 @@ export class AudioController {
     await this.currentAdapter!.loadTrack(track.url);
     this.currentTrack = track;
     this.currentIndex = index;
+
+    if (this.onTrackEndCallback) {
+      this.onTrackEndCallback();
+    }
   }
 
   // NAVIGATION
@@ -129,6 +138,14 @@ export class AudioController {
       return;
     }
     this.currentAdapter.setVolume(value);
+  }
+
+  private async handleTrackEnd(): Promise<void> {
+    await this.nextTrack();
+  }
+
+  onTrackEnd(callback: () => void): void {
+    this.onTrackEndCallback = callback;
   }
 
   // GETTERS

--- a/src/app/_components/player/adapters/SoundCloudAdapter.ts
+++ b/src/app/_components/player/adapters/SoundCloudAdapter.ts
@@ -9,6 +9,7 @@ declare global {
           READY: string;
           ERROR: string;
           LOAD_PROGRESS: number;
+          FINISH: string;
         };
       };
     };
@@ -38,6 +39,7 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
   private isReady: boolean = false;
   private isInitialized: boolean = false;
   private currentSound: SoundCloudSound | null = null;
+  private onTrackEndCallback: (() => void) | null = null;
 
   constructor(iframeId: string = "soundcloud-player") {
     this.iframeId = iframeId;
@@ -103,6 +105,12 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
 
         this.player.bind(window.SC.Widget.Events.ERROR, (error?: string) => {
           console.warn(`SoundCloud widget error: ${error}`);
+        });
+
+        this.player.bind(window.SC.Widget.Events.FINISH, () => {
+          if (this.onTrackEndCallback) {
+            this.onTrackEndCallback();
+          }
         });
       };
 
@@ -206,6 +214,10 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
     }
 
     this.player.setVolume(value);
+  }
+
+  onTrackEnd(callback: () => void): void {
+    this.onTrackEndCallback = callback;
   }
 
   get duration(): number {

--- a/src/app/_components/player/types/player.ts
+++ b/src/app/_components/player/types/player.ts
@@ -8,6 +8,7 @@ export interface MusicPlayerAdapter {
   setVolume(value: number): void;
   readonly duration: number;
   readonly sound: SoundCloudSound | null;
+  onTrackEnd(callback: () => void): void;
 }
 
 export interface SoundCloudSound {

--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -66,6 +66,13 @@ export function useMusicPlayer() {
     if (!controller) {
       try {
         const controller = new AudioController();
+
+        // TODO: this area is a little funky, refactor after logic of fetching from playlist updating data of songs.
+        controller.onTrackEnd(() => {
+          setCurrentTime(0);
+          setDuration(controller.duration);
+        });
+
         await controller.loadPlaylist(testPlaylist);
         setController(controller);
         setIsLoaded(true);


### PR DESCRIPTION
### TL;DR

Added automatic track progression when a song finishes playing.

### What changed?

- Implemented track end detection in the SoundCloudAdapter by binding to the SC.Widget.Events.FINISH event
- Added an onTrackEnd callback mechanism to both the adapter and AudioController
- Created a handleTrackEnd method in AudioController that automatically plays the next track
- Updated the MusicPlayerAdapter interface to include the onTrackEnd method
- Added state reset logic in useMusicPlayer when a track ends

