### PR TITLE
flatten returned playlist data

### DIFF
--- a/src/app/_components/player/types/player.ts
+++ b/src/app/_components/player/types/player.ts
@@ -25,8 +25,18 @@ export interface SoundCloudSound {
   waveform_url: string;
 }
 
+export interface PlaylistTrack {
+  playlistId: number;
+  playlistName: string;
+  trackId: number;
+  position: number;
+  albumId: number | null;
+  artists: { artistId: number; artistName: string }[];
+  title: string;
+}
+
 export interface Track {
-  // id: string;
+  id: number;
   title: string;
   // artist?: string;
   url: string;

--- a/src/app/playlist/[id]/PlaylistItem.tsx
+++ b/src/app/playlist/[id]/PlaylistItem.tsx
@@ -7,7 +7,7 @@ interface PlaylistItemProps {
   index: number;
   title: string;
   position: number;
-  artists: { artist: { name: string } }[];
+  artists: { artistId: number; artistName: string }[];
 }
 
 export const PlaylistItem = ({
@@ -29,7 +29,7 @@ export const PlaylistItem = ({
         {hovered ? <Play /> : <p>{index + 1}</p>}
         <div className="flex flex-col">
           <p>{title}</p>
-          <p>{artists.map((artist) => artist.artist.name).join(", ")}</p>
+          <p>{artists.map((artist) => artist.artistName).join(", ")}</p>
         </div>
       </div>
       <div className="flex flex-row">

--- a/src/app/playlist/[id]/page.tsx
+++ b/src/app/playlist/[id]/page.tsx
@@ -6,19 +6,20 @@ const Playlist = async ({ params }: { params: Promise<{ id: string }> }) => {
   const playlist = await api.playlists.getById({
     id: parseInt(playlistId),
   });
-  const songs = playlist?.playlistEntries;
+
+  if (!playlist) return <div>Playlist not found</div>;
 
   return (
     <div className="grid w-full place-items-center">
-      <h1 className="mt-7">{playlist?.name}</h1>
-      {songs?.map((song, index) => {
+      <h1 className="mt-7">{playlist[0]?.playlistName}</h1>
+      {playlist?.map((song, index) => {
         return (
           <PlaylistItem
             key={song.position}
             index={index}
-            title={song.libraryTrack.title}
+            title={song.title}
             position={song.position}
-            artists={song.libraryTrack.artists}
+            artists={song.artists}
           />
         );
       })}

--- a/src/server/api/routers/playlists.ts
+++ b/src/server/api/routers/playlists.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import type { PlaylistTrack } from "~/app/_components/player/types/player";
 
 export const playlistsRouter = createTRPCRouter({
   getAll: protectedProcedure.query(async ({ ctx }) => {
@@ -12,10 +13,11 @@ export const playlistsRouter = createTRPCRouter({
       },
     });
   }),
+
   getById: protectedProcedure
     .input(z.object({ id: z.number() }))
-    .query(async ({ ctx, input }) => {
-      return ctx.db.playlist.findUnique({
+    .query(async ({ ctx, input }): Promise<PlaylistTrack[] | []> => {
+      const dbPlaylist = await ctx.db.playlist.findUnique({
         where: {
           id: input.id,
           userId: ctx.user.id,
@@ -36,5 +38,28 @@ export const playlistsRouter = createTRPCRouter({
           },
         },
       });
+
+      if (!dbPlaylist) return [];
+
+      const flattenedPlaylist = dbPlaylist.playlistEntries
+        .map((entry) => {
+          return {
+            playlistId: entry.playlistId,
+            playlistName: dbPlaylist.name,
+            trackId: entry.libraryTrackId,
+            position: entry.position,
+            albumId: entry.libraryTrack.albumId,
+            artists: entry.libraryTrack.artists.map((artist) => {
+              return {
+                artistId: artist.artistId,
+                artistName: artist.artist.name,
+              };
+            }),
+            title: entry.libraryTrack.title,
+          };
+        })
+        .sort((a, b) => a.position - b.position);
+
+      return flattenedPlaylist;
     }),
 });


### PR DESCRIPTION
### TL;DR

Refactored the returned playlist data structure to be flattened for easier usability. 

### What changed?

- Added a new `PlaylistTrack` interface to standardize playlist track data
- Modified the `getById` procedure in the playlists router to return flattened playlist data
- Updated the playlist page and PlaylistItem component to use the new data structure

### Why make this change?

This change simplifies the data structure for playlists, making it more consistent and easier to work with throughout the application. By flattening the nested data structure and standardizing the format, we reduce complexity in the UI components and make the code more maintainable. The addition of IDs for tracks and artists also enables better tracking and manipulation of these entities.