### PR TITLE
move to zustand state, many fixes as well

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["autoincrement", "soundcloud", "streamable"]
+  "cSpell.words": ["autoincrement", "dont", "soundcloud", "streamable"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "server-only": "^0.0.1",
         "superjson": "^2.2.1",
         "tailwind-merge": "^3.3.1",
-        "zod": "^3.24.2"
+        "zod": "^3.24.2",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -8655,6 +8656,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "server-only": "^0.0.1",
     "superjson": "^2.2.1",
     "tailwind-merge": "^3.3.1",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -1,18 +1,19 @@
 import { SoundCloudAdapter } from "./adapters/SoundCloudAdapter";
 import type {
   MusicPlayerAdapter,
-  Track,
+  PlaylistTrack,
   SoundCloudSound,
 } from "./types/player";
 
 export class AudioController {
   private currentAdapter: MusicPlayerAdapter | null = null;
-  private currentTrack: Track | null = null;
-  private playlist: Track[] = [];
+  private currentTrack: PlaylistTrack | null = null;
+  private playlist: PlaylistTrack[] = [];
   private currentIndex: number = -1;
-  private onTrackEndCallback: (() => void) | null = null;
 
-  private async createAdapterForSource(source: Track["source"]): Promise<void> {
+  private async createAdapterForSource(
+    source: PlaylistTrack["source"],
+  ): Promise<void> {
     // if we don't have a current adapter, or the we're swapping source type, reset the adapter
     if (this.currentAdapter && this.currentTrack?.source !== source) {
       this.currentAdapter = null;
@@ -22,10 +23,6 @@ export class AudioController {
       switch (source) {
         case "soundcloud":
           this.currentAdapter = new SoundCloudAdapter();
-          this.currentAdapter.onTrackEnd(() => {
-            console.log("track end");
-            void this.handleTrackEnd();
-          });
           break;
         default:
           console.error(`Unsupported track source: ${source}`);
@@ -33,19 +30,19 @@ export class AudioController {
     }
   }
 
-  async loadPlaylist(playlist: Track[]) {
+  async loadPlaylist(playlist: PlaylistTrack[], index: number) {
     this.playlist = playlist;
-    this.currentIndex = 0;
+    this.currentIndex = index;
 
     if (this.playlist.length > 0) {
-      await this.createAdapterForSource(this.playlist[0]!.source);
+      await this.createAdapterForSource(this.playlist[index]!.source);
       await this.loadTrackByIndex(this.currentIndex);
     }
   }
 
-  async loadTrack(track: Track) {
+  async loadTrack(track: PlaylistTrack) {
     await this.createAdapterForSource(track.source);
-    await this.currentAdapter!.loadTrack(track.url);
+    await this.currentAdapter!.loadTrack(track.sourceIdentifier);
     this.currentTrack = track;
   }
 
@@ -63,13 +60,9 @@ export class AudioController {
 
     await this.createAdapterForSource(track.source);
 
-    await this.currentAdapter!.loadTrack(track.url);
+    await this.currentAdapter!.loadTrack(track.sourceIdentifier);
     this.currentTrack = track;
     this.currentIndex = index;
-
-    if (this.onTrackEndCallback) {
-      this.onTrackEndCallback();
-    }
   }
 
   // NAVIGATION
@@ -140,14 +133,6 @@ export class AudioController {
     this.currentAdapter.setVolume(value);
   }
 
-  private async handleTrackEnd(): Promise<void> {
-    await this.nextTrack();
-  }
-
-  onTrackEnd(callback: () => void): void {
-    this.onTrackEndCallback = callback;
-  }
-
   // GETTERS
   private canGoNext(): boolean {
     return this.currentIndex < this.playlist.length - 1;
@@ -157,7 +142,7 @@ export class AudioController {
     return this.currentIndex > 0;
   }
 
-  getCurrentTrack(): Track | null {
+  getCurrentTrack(): PlaylistTrack | null {
     return this.currentTrack;
   }
 

--- a/src/app/_components/player/MusicPlayer.tsx
+++ b/src/app/_components/player/MusicPlayer.tsx
@@ -4,13 +4,13 @@ import { useMusicPlayer } from "./useMusicPlayer";
 import { ProgressBar } from "./components/ProgressBar";
 import { PlaybackControl } from "./components/PlaybackControl";
 import { VolumeControl } from "./components/VolumeControl";
+import { useMusicPlayerStore } from "./MusicPlayerStore";
 
 export const MusicPlayer = () => {
+  const { loadedOnce, isPlaying, volume, duration, currentTime } =
+    useMusicPlayerStore();
+
   const {
-    isPlaying,
-    volume,
-    duration,
-    currentTime,
     play,
     pause,
     next,
@@ -19,6 +19,8 @@ export const MusicPlayer = () => {
     handleProgressChange,
     handleProgressCommit,
   } = useMusicPlayer();
+
+  if (!loadedOnce) return null;
 
   return (
     <div className="fixed bottom-10 left-1/2 z-100 flex -translate-x-1/2 gap-4">

--- a/src/app/_components/player/MusicPlayerStore.ts
+++ b/src/app/_components/player/MusicPlayerStore.ts
@@ -1,0 +1,95 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import type { PlaylistTrack } from "./types/player";
+import type { AudioController } from "./AudioController";
+
+interface MusicPlayerState {
+  // playlist state
+  currentPlaylist: PlaylistTrack[] | null;
+  currentPlaylistId: number | null;
+  currentTrackIndex: number;
+
+  // player state
+  isPlaying: boolean;
+  isLoaded: boolean;
+  volume: number;
+  duration: number;
+  currentTime: number;
+  isSeeking: boolean;
+  loadedOnce: boolean;
+
+  // controller
+  controller: AudioController | null;
+
+  // actions
+  setCurrentPlaylist: (playlist: PlaylistTrack[], playlistId: number) => void;
+  setCurrentTrackIndex: (trackIndex: number) => void;
+  setIsPlaying: (isPlaying: boolean) => void;
+  setIsLoaded: (isLoaded: boolean) => void;
+  setVolume: (volume: number) => void;
+  setDuration: (duration: number) => void;
+  setCurrentTime: (currentTime: number) => void;
+  setIsSeeking: (isSeeking: boolean) => void;
+  setLoadedOnce: (loadedOnce: boolean) => void;
+  setController: (controller: AudioController) => void;
+
+  // computed values
+  currentTrack: PlaylistTrack | null;
+  hasNextTrack: boolean;
+  hasPreviousTrack: boolean;
+}
+
+export const useMusicPlayerStore = create<MusicPlayerState>()(
+  devtools(
+    (set) => ({
+      currentPlaylist: null,
+      currentPlaylistId: null,
+      currentTrackIndex: 0,
+      isPlaying: false,
+      isLoaded: false,
+      volume: 100,
+      duration: 0,
+      currentTime: 0,
+      isSeeking: false,
+      loadedOnce: false,
+
+      setCurrentPlaylist: (playlist: PlaylistTrack[], playlistId: number) =>
+        set({
+          currentPlaylist: playlist,
+          currentPlaylistId: playlistId,
+          currentTrackIndex: 0,
+          currentTime: 0,
+          duration: 0,
+          isLoaded: false,
+          isPlaying: false,
+        }),
+
+      setCurrentTrackIndex: (index: number) =>
+        set({ currentTrackIndex: index }),
+      setIsPlaying: (playing: boolean) => set({ isPlaying: playing }),
+      setIsLoaded: (loaded: boolean) => set({ isLoaded: loaded }),
+      setVolume: (volume: number) => set({ volume }),
+      setDuration: (duration: number) => set({ duration }),
+      setCurrentTime: (time: number) => set({ currentTime: time }),
+      setIsSeeking: (seeking: boolean) => set({ isSeeking: seeking }),
+      setLoadedOnce: (loadedOnce: boolean) => set({ loadedOnce: loadedOnce }),
+      setController: (controller: AudioController) => set({ controller }),
+    }),
+    {
+      name: "music-player-store",
+    },
+  ),
+);
+
+// computed getters didn't work with devtools, so moving outside
+export const useMusicPlayerComputed = () => {
+  const { currentPlaylist, currentTrackIndex } = useMusicPlayerStore();
+
+  return {
+    currentTrack: currentPlaylist?.[currentTrackIndex] ?? null,
+    hasNextTrack: currentPlaylist
+      ? currentTrackIndex < currentPlaylist.length - 1
+      : false,
+    hasPreviousTrack: currentTrackIndex > 0,
+  };
+};

--- a/src/app/_components/player/adapters/SoundCloudAdapter.ts
+++ b/src/app/_components/player/adapters/SoundCloudAdapter.ts
@@ -39,7 +39,6 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
   private isReady: boolean = false;
   private isInitialized: boolean = false;
   private currentSound: SoundCloudSound | null = null;
-  private onTrackEndCallback: (() => void) | null = null;
 
   constructor(iframeId: string = "soundcloud-player") {
     this.iframeId = iframeId;
@@ -108,9 +107,8 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
         });
 
         this.player.bind(window.SC.Widget.Events.FINISH, () => {
-          if (this.onTrackEndCallback) {
-            this.onTrackEndCallback();
-          }
+          // deprecated, unreliable for now
+          // just handling with duration checks
         });
       };
 
@@ -214,10 +212,6 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
     }
 
     this.player.setVolume(value);
-  }
-
-  onTrackEnd(callback: () => void): void {
-    this.onTrackEndCallback = callback;
   }
 
   get duration(): number {

--- a/src/app/_components/player/types/player.ts
+++ b/src/app/_components/player/types/player.ts
@@ -8,7 +8,6 @@ export interface MusicPlayerAdapter {
   setVolume(value: number): void;
   readonly duration: number;
   readonly sound: SoundCloudSound | null;
-  onTrackEnd(callback: () => void): void;
 }
 
 export interface SoundCloudSound {
@@ -33,14 +32,7 @@ export interface PlaylistTrack {
   albumId: number | null;
   artists: { artistId: number; artistName: string }[];
   title: string;
-}
-
-export interface Track {
-  id: number;
-  title: string;
-  // artist?: string;
-  url: string;
   source: "spotify" | "soundcloud" | "youtube" | "local";
-  duration?: number;
-  // artwork?: string;
+  sourceIdentifier: string;
+  duration: number | null;
 }

--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -1,30 +1,33 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useCallback } from "react";
 import { AudioController } from "./AudioController";
-import type { Track } from "./types/player";
-
-const testPlaylist: Track[] = [
-  {
-    title: "year walk",
-    url: "https://soundcloud.com/evens/evens-year-walk-free-download",
-    source: "soundcloud",
-    // duration: 120,
-  },
-  {
-    title: "dont want",
-    url: "https://soundcloud.com/janu4ryss/dont-want-u-prod-me",
-    source: "soundcloud",
-    // duration: 180,
-  },
-];
+import {
+  useMusicPlayerStore,
+  useMusicPlayerComputed,
+} from "./MusicPlayerStore";
 
 export function useMusicPlayer() {
-  const [controller, setController] = useState<AudioController | null>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [volume, setVolume] = useState(100);
-  const [duration, setDuration] = useState(0);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [isSeeking, setIsSeeking] = useState(false);
+  const {
+    currentPlaylist,
+    currentTrackIndex,
+    isPlaying,
+    isLoaded,
+    volume,
+    currentTime,
+    controller,
+    isSeeking,
+    setCurrentTime,
+    setDuration,
+    setIsPlaying,
+    setIsLoaded,
+    setCurrentTrackIndex,
+    setVolume,
+    setIsSeeking,
+    setLoadedOnce,
+    setController,
+    duration,
+  } = useMusicPlayerStore();
+
+  const { hasNextTrack, hasPreviousTrack } = useMusicPlayerComputed();
 
   // load soundcloud script
   useEffect(() => {
@@ -45,11 +48,22 @@ export function useMusicPlayer() {
   useEffect(() => {
     let interval: NodeJS.Timeout;
 
-    if (isPlaying && controller && isLoaded) {
+    if (isPlaying && isLoaded) {
       interval = setInterval(() => {
-        if (!isSeeking) {
+        if (!isSeeking && controller) {
           void controller.getCurrentTime().then((time) => {
             setCurrentTime(time);
+
+            if (duration > 0 && time >= duration - 0.5) {
+              if (hasNextTrack) {
+                void next();
+              } else {
+                // End of playlist
+                setCurrentTime(0);
+                setDuration(0);
+                setIsPlaying(false);
+              }
+            }
           });
         }
       }, 500);
@@ -60,57 +74,114 @@ export function useMusicPlayer() {
         clearInterval(interval);
       }
     };
-  }, [isPlaying, controller, isLoaded, isSeeking]);
+    // next is a useCallback with its own dependencies, no need to include here
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isPlaying,
+    isLoaded,
+    isSeeking,
+    setCurrentTime,
+    controller,
+    setDuration,
+    setIsPlaying,
+    hasNextTrack,
+    duration,
+  ]);
 
   const play = useCallback(async () => {
+    setLoadedOnce(true);
+    // needed the freshest values from the store as before when calling play,
+    // the react state hadn't updated yet with the new values.
+    // other areas aren't same tick updates so it should be fine.
+    const { currentPlaylist, currentTrackIndex } =
+      useMusicPlayerStore.getState();
+
+    if (!currentPlaylist || currentPlaylist.length === 0) {
+      console.warn("No playlist loaded");
+      return;
+    }
+
+    const currentTrack = currentPlaylist[currentTrackIndex];
+    if (!currentTrack) {
+      console.warn("No current track");
+      return;
+    }
+
     if (!controller) {
       try {
-        const controller = new AudioController();
+        const newController = new AudioController();
 
-        // TODO: this area is a little funky, refactor after logic of fetching from playlist updating data of songs.
-        controller.onTrackEnd(() => {
-          setCurrentTime(0);
-          setDuration(controller.duration);
-        });
-
-        await controller.loadPlaylist(testPlaylist);
-        setController(controller);
+        await newController.loadPlaylist(currentPlaylist, currentTrackIndex);
+        setController(newController);
         setIsLoaded(true);
-        await controller.play();
-        controller.setVolume(volume);
-        setDuration(controller.duration);
+        await newController.play();
+        newController.setVolume(volume);
+        setDuration(newController.duration);
         setIsPlaying(true);
       } catch (error) {
         console.error("Failed to load playlist:", error);
       }
-    }
-
-    if (controller && isLoaded) {
-      await controller.play();
+    } else if (controller && isLoaded) {
+      const controllerCurrentIndex = controller.getCurrentIndex();
+      if (controllerCurrentIndex !== currentTrackIndex) {
+        try {
+          await controller.loadPlaylist(currentPlaylist, currentTrackIndex);
+          setCurrentTime(0);
+          setDuration(controller.duration);
+          await controller.play();
+          controller.setVolume(volume);
+        } catch (error) {
+          console.error("Failed to load new track:", error);
+        }
+      } else {
+        await controller.play();
+      }
       setIsPlaying(true);
     }
-  }, [controller, isLoaded, volume]);
+  }, [
+    controller,
+    isLoaded,
+    volume,
+    setCurrentTime,
+    setDuration,
+    setIsPlaying,
+    setIsLoaded,
+    setLoadedOnce,
+    setController,
+  ]);
 
   const pause = useCallback(async () => {
     if (controller && isLoaded) {
       await controller.pause();
       setIsPlaying(false);
     }
-  }, [controller, isLoaded]);
+  }, [controller, isLoaded, setIsPlaying]);
 
   const next = useCallback(async () => {
-    if (controller && isLoaded) {
+    if (currentPlaylist && hasNextTrack && controller) {
+      setCurrentTrackIndex(currentTrackIndex + 1);
       // hacky loading state to get the slider and duration to properly display while loading next track
       setCurrentTime(0.01);
       setDuration(0.9);
       await controller.nextTrack();
       controller.setVolume(volume);
       setDuration(controller.duration);
+      setIsPlaying(true);
     }
-  }, [controller, isLoaded, volume]);
+  }, [
+    controller,
+    volume,
+    currentPlaylist,
+    hasNextTrack,
+    currentTrackIndex,
+    setCurrentTrackIndex,
+    setCurrentTime,
+    setDuration,
+    setIsPlaying,
+  ]);
 
   const previous = useCallback(async () => {
-    if (controller && isLoaded) {
+    if (currentPlaylist && hasPreviousTrack && controller) {
       // user expectation, if into the song, hitting previous should go back to the start
       // if at the start, go previous track
       if (currentTime > 3) {
@@ -119,13 +190,26 @@ export function useMusicPlayer() {
         return;
       }
 
+      setCurrentTrackIndex(currentTrackIndex - 1);
       setCurrentTime(0.01);
       setDuration(0.9);
       await controller.previousTrack();
       controller.setVolume(volume);
       setDuration(controller.duration);
+      setIsPlaying(true);
     }
-  }, [controller, isLoaded, volume, currentTime]);
+  }, [
+    controller,
+    volume,
+    currentTime,
+    currentPlaylist,
+    hasPreviousTrack,
+    setCurrentTime,
+    currentTrackIndex,
+    setDuration,
+    setCurrentTrackIndex,
+    setIsPlaying,
+  ]);
 
   const handleVolumeChange = useCallback(
     (volume: number[]) => {
@@ -137,7 +221,7 @@ export function useMusicPlayer() {
         }
       }
     },
-    [controller, isLoaded],
+    [controller, isLoaded, setVolume],
   );
 
   const handleProgressChange = useCallback(
@@ -147,7 +231,7 @@ export function useMusicPlayer() {
         setCurrentTime(value[0]);
       }
     },
-    [controller, isLoaded],
+    [controller, isLoaded, setIsSeeking, setCurrentTime],
   );
 
   const handleProgressCommit = useCallback(
@@ -157,14 +241,10 @@ export function useMusicPlayer() {
         setIsSeeking(false);
       }
     },
-    [controller, isLoaded],
+    [controller, isLoaded, setIsSeeking],
   );
 
   return {
-    isPlaying,
-    volume,
-    duration,
-    currentTime,
     play,
     pause,
     next,

--- a/src/app/playlist/[id]/PlaylistItem.tsx
+++ b/src/app/playlist/[id]/PlaylistItem.tsx
@@ -2,12 +2,18 @@
 
 import { useState } from "react";
 import { Ellipsis, Play } from "lucide-react";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
+import { useMusicPlayer } from "~/app/_components/player/useMusicPlayer";
+import type { PlaylistTrack } from "~/app/_components/player/types/player";
+import { Button } from "~/components/ui/button";
 
 interface PlaylistItemProps {
   index: number;
   title: string;
   position: number;
   artists: { artistId: number; artistName: string }[];
+  playlist: PlaylistTrack[];
+  playlistId: number;
 }
 
 export const PlaylistItem = ({
@@ -15,18 +21,47 @@ export const PlaylistItem = ({
   title,
   position,
   artists,
+  playlist,
+  playlistId,
 }: PlaylistItemProps) => {
   const [hovered, setHovered] = useState(false);
+
+  const {
+    currentPlaylistId,
+    currentTrackIndex,
+    setCurrentPlaylist,
+    setCurrentTrackIndex,
+  } = useMusicPlayerStore();
+
+  const { play } = useMusicPlayer();
+
+  const isCurrentTrack =
+    currentPlaylistId === playlistId && currentTrackIndex === index;
+
+  const handlePlay = async () => {
+    if (currentPlaylistId !== playlistId) {
+      setCurrentPlaylist(playlist, playlistId);
+    }
+    setCurrentTrackIndex(index);
+
+    await play();
+  };
 
   return (
     <div
       key={position}
-      className="flex w-7/10 flex-row items-center justify-between border border-blue-500"
+      className={`flex w-7/10 flex-row items-center justify-between ${isCurrentTrack ? "border-green-500 bg-green-50" : "border-blue-500"}`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
       <div className="flex flex-row items-center gap-4">
-        {hovered ? <Play /> : <p>{index + 1}</p>}
+        {hovered ? (
+          <Button onClick={handlePlay}>
+            <Play />
+          </Button>
+        ) : (
+          <p>{index + 1}</p>
+        )}
         <div className="flex flex-col">
           <p>{title}</p>
           <p>{artists.map((artist) => artist.artistName).join(", ")}</p>

--- a/src/app/playlist/[id]/page.tsx
+++ b/src/app/playlist/[id]/page.tsx
@@ -20,6 +20,8 @@ const Playlist = async ({ params }: { params: Promise<{ id: string }> }) => {
             title={song.title}
             position={song.position}
             artists={song.artists}
+            playlist={playlist}
+            playlistId={song.playlistId}
           />
         );
       })}

--- a/src/server/api/routers/playlists.ts
+++ b/src/server/api/routers/playlists.ts
@@ -27,6 +27,7 @@ export const playlistsRouter = createTRPCRouter({
             include: {
               libraryTrack: {
                 include: {
+                  track: true,
                   artists: {
                     include: {
                       artist: true,
@@ -56,6 +57,9 @@ export const playlistsRouter = createTRPCRouter({
               };
             }),
             title: entry.libraryTrack.title,
+            source: entry.libraryTrack.track.source,
+            sourceIdentifier: entry.libraryTrack.track.sourceIdentifier,
+            duration: entry.libraryTrack.track.duration,
           };
         })
         .sort((a, b) => a.position - b.position);


### PR DESCRIPTION
### TL;DR

Added Zustand state management to the music player component, enabling persistent playback state and playlist management. Refactoring around the board.

### What changed?

- Added Zustand for state management
- Created a `MusicPlayerStore` to centralize player state
- Refactored `AudioController` and adapters to work with the store
- Updated the `PlaylistTrack` type to include source information
- Implemented proper track navigation with playlist context
- Added UI indicators for the currently playing track
- Improved track end detection and automatic playback of next track, removed the bubbling of the 'finish' event in favor of duration checking (for now)
- Connected playlist items to the player for direct playback


### Why make this change?

The previous implementation lacked proper state management, making it difficult to maintain playback state across components and page navigation. By centralizing state with Zustand, we can now:

- Maintain playback state across component re-renders
- Provide a consistent API for controlling playback
- Enable direct playback from playlist items
- Improve the user experience with visual indicators for the current track
- Support more robust playlist navigation and track management
- easier integration for future sources