### PR TITLE
persisting adapters and letting the controller delegate pausing between tracks

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -134,12 +134,12 @@ const seed = async () => {
         libraryTrackId: libraryTrack1.id,
       },
       {
-        position: 2,
+        position: 3,
         playlistId: playlist.id,
         libraryTrackId: libraryTrack2.id,
       },
       {
-        position: 3,
+        position: 2,
         playlistId: playlist.id,
         libraryTrackId: libraryTrack3.id,
       },

--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -11,27 +11,32 @@ export class AudioController {
   private currentTrack: PlaylistTrack | null = null;
   private playlist: PlaylistTrack[] = [];
   private currentIndex: number = -1;
+  private adapters = new Map<string, MusicPlayerAdapter>();
 
   private async createAdapterForSource(
     source: PlaylistTrack["source"],
   ): Promise<void> {
-    // if we don't have a current adapter, or the we're swapping source type, reset the adapter
-    if (this.currentAdapter && this.currentTrack?.source !== source) {
-      this.currentAdapter = null;
+    // persist adapter update
+    if (this.adapters.has(source)) {
+      this.currentAdapter = this.adapters.get(source)!;
+      return;
     }
 
-    if (!this.currentAdapter) {
-      switch (source) {
-        case "soundcloud":
-          this.currentAdapter = new SoundCloudAdapter();
-          break;
-        case "youtube":
-          this.currentAdapter = new YouTubeAdapter();
-          break;
-        default:
-          console.error(`Unsupported track source: ${source}`);
-      }
+    let adapter: MusicPlayerAdapter;
+    switch (source) {
+      case "soundcloud":
+        adapter = new SoundCloudAdapter();
+        break;
+      case "youtube":
+        adapter = new YouTubeAdapter();
+        break;
+      default:
+        console.error(`Unsupported track source: ${source}`);
+        return;
     }
+
+    this.adapters.set(source, adapter);
+    this.currentAdapter = adapter;
   }
 
   async loadPlaylist(playlist: PlaylistTrack[], index: number) {
@@ -62,8 +67,12 @@ export class AudioController {
       return;
     }
 
-    await this.createAdapterForSource(track.source);
+    // if check, only to filter the noise on first play
+    if (this.currentAdapter) {
+      this.currentAdapter.pause();
+    }
 
+    await this.createAdapterForSource(track.source);
     await this.currentAdapter!.loadTrack(track.sourceIdentifier);
     this.currentTrack = track;
     this.currentIndex = index;

--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -169,9 +169,11 @@ export function useMusicPlayer() {
   const next = useCallback(async () => {
     if (currentPlaylist && hasNextTrack && controller) {
       setCurrentTrackIndex(currentTrackIndex + 1);
+
       // hacky loading state to get the slider and duration to properly display while loading next track
       setCurrentTime(0.01);
       setDuration(0.9);
+
       await controller.nextTrack();
       controller.setVolume(volume);
       setDuration(controller.duration);
@@ -200,8 +202,10 @@ export function useMusicPlayer() {
       }
 
       setCurrentTrackIndex(currentTrackIndex - 1);
+
       setCurrentTime(0.01);
       setDuration(0.9);
+
       await controller.previousTrack();
       controller.setVolume(volume);
       setDuration(controller.duration);


### PR DESCRIPTION
### TL;DR

Improved music player functionality with persistent adapters rather than loading a new one up on every source switch. Also re-delegates control back to the audiocontroller during song switches rather than the useMusicPlayer hook handling this. 

### What changed?

- Enhanced `AudioController` to maintain persistent adapters for different music sources (YouTube, SoundCloud) 
- Added proper pause handling when switching between tracks from different sources




### Why make this change?

The previous implementation recreated adapters each time a track source changed, which was inefficient. This update maintains adapter instances for each source type, improving performance and resource usage. 