### PR TITLE
updating song metadata

### DIFF
--- a/prisma/migrations/20250917235842_updating_track_metadata/migration.sql
+++ b/prisma/migrations/20250917235842_updating_track_metadata/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `sourceIdentifier` on the `Track` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[source,sourceId]` on the table `Track` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "public"."Track_source_sourceIdentifier_key";
+
+-- AlterTable
+ALTER TABLE "public"."Track" DROP COLUMN "sourceIdentifier",
+ADD COLUMN     "artworkUrl" TEXT,
+ADD COLUMN     "isPlayable" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "sourceId" TEXT,
+ADD COLUMN     "sourceUrl" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Track_source_sourceId_key" ON "public"."Track"("source", "sourceId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,11 +58,14 @@ model Track {
 
     duration           Int?
     source             SongSource
-    sourceIdentifier   String
+    sourceId           String?
+    sourceUrl          String?
+    artworkUrl         String?
+    isPlayable         Boolean @default(true)
 
     libraryTracks   LibraryTrack[]
 
-    @@unique ([source, sourceIdentifier])
+    @@unique ([source, sourceId])
 }
 
 // join table for each entry in a playlist, position enforces order for display

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -16,8 +16,7 @@ const seed = async () => {
   const track1 = await db.track.create({
     data: {
       source: "soundcloud",
-      sourceIdentifier:
-        "https://soundcloud.com/evens/evens-year-walk-free-download",
+      sourceUrl: "https://soundcloud.com/evens/evens-year-walk-free-download",
     },
   });
   console.log("year walk added");
@@ -25,7 +24,7 @@ const seed = async () => {
   const track2 = await db.track.create({
     data: {
       source: "soundcloud",
-      sourceIdentifier: "https://soundcloud.com/janu4ryss/dont-want-u-prod-me",
+      sourceUrl: "https://soundcloud.com/janu4ryss/dont-want-u-prod-me",
     },
   });
   console.log("dont want u added");
@@ -33,7 +32,7 @@ const seed = async () => {
   const track3 = await db.track.create({
     data: {
       source: "youtube",
-      sourceIdentifier: "-bORJzjLGSU",
+      sourceId: "-bORJzjLGSU",
     },
   });
   console.log("transcendence added");
@@ -41,7 +40,7 @@ const seed = async () => {
   const track4 = await db.track.create({
     data: {
       source: "youtube",
-      sourceIdentifier: "3K6POJzvZlI",
+      sourceId: "3K6POJzvZlI",
     },
   });
   console.log("xtayalive added");


### PR DESCRIPTION
### TL;DR

Updated Track model to better handle source metadata with separate sourceId and sourceUrl fields.

### What changed?

- Removed `sourceIdentifier` field from Track model and replaced it with:
  - `sourceId`: For storing platform-specific IDs
  - `sourceUrl`: For storing full URLs to tracks
  - `artworkUrl`: For storing track artwork
  - `isPlayable`: Boolean flag to indicate if a track can be played (defaults to true)
- Updated unique constraint to use `source` and `sourceId` instead of `sourceIdentifier`
- Created a new migration file to handle these schema changes
- Updated seed data to use the new fields appropriately:
  - YouTube tracks now use `sourceId` for video IDs
  - SoundCloud tracks now use `sourceUrl` for full URLs
