### PR TITLE
update app to use new sourceId and sourceUrl

### DIFF
--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -51,8 +51,21 @@ export class AudioController {
 
   async loadTrack(track: PlaylistTrack) {
     await this.createAdapterForSource(track.source);
-    await this.currentAdapter!.loadTrack(track.sourceIdentifier);
+    const trackIdentifier = this.getTrackIdentifier(track);
+    await this.currentAdapter!.loadTrack(trackIdentifier!);
     this.currentTrack = track;
+  }
+
+  private getTrackIdentifier(track: PlaylistTrack) {
+    switch (track.source) {
+      case "soundcloud":
+        return track.sourceUrl;
+      case "youtube":
+        return track.sourceId;
+      default:
+        console.error(`Unsupported track source: ${track.source}`);
+        return "";
+    }
   }
 
   private async loadTrackByIndex(index: number) {
@@ -73,7 +86,8 @@ export class AudioController {
     }
 
     await this.createAdapterForSource(track.source);
-    await this.currentAdapter!.loadTrack(track.sourceIdentifier);
+    const trackIdentifier = this.getTrackIdentifier(track);
+    await this.currentAdapter!.loadTrack(trackIdentifier!); // based on source type, we know the identifier will exist
     this.currentTrack = track;
     this.currentIndex = index;
   }

--- a/src/app/_components/player/types/player.ts
+++ b/src/app/_components/player/types/player.ts
@@ -33,6 +33,8 @@ export interface PlaylistTrack {
   artists: { artistId: number; artistName: string }[];
   title: string;
   source: "spotify" | "soundcloud" | "youtube" | "local";
-  sourceIdentifier: string;
+  sourceId: string | null;
+  sourceUrl: string | null;
+  artworkUrl: string | null;
   duration: number | null;
 }

--- a/src/app/library/DataTable.tsx
+++ b/src/app/library/DataTable.tsx
@@ -23,7 +23,9 @@ export type LibraryTrack = {
   album: { id: number; name: string } | null;
   duration: number | null;
   source: "soundcloud" | "spotify" | "youtube" | "local";
-  sourceIdentifier: string;
+  sourceId: string | null;
+  sourceUrl: string | null;
+  artworkUrl: string | null;
 };
 
 const columns: ColumnDef<LibraryTrack>[] = [

--- a/src/server/api/routers/library.ts
+++ b/src/server/api/routers/library.ts
@@ -33,7 +33,9 @@ export const libraryRouter = createTRPCRouter({
         album: track.album,
         duration: track.track.duration,
         source: track.track.source,
-        sourceIdentifier: track.track.sourceIdentifier,
+        sourceId: track.track.sourceId,
+        sourceUrl: track.track.sourceUrl,
+        artworkUrl: track.track.artworkUrl,
       };
     });
 

--- a/src/server/api/routers/playlists.ts
+++ b/src/server/api/routers/playlists.ts
@@ -58,7 +58,9 @@ export const playlistsRouter = createTRPCRouter({
             }),
             title: entry.libraryTrack.title,
             source: entry.libraryTrack.track.source,
-            sourceIdentifier: entry.libraryTrack.track.sourceIdentifier,
+            sourceId: entry.libraryTrack.track.sourceId,
+            sourceUrl: entry.libraryTrack.track.sourceUrl,
+            artworkUrl: entry.libraryTrack.track.artworkUrl,
             duration: entry.libraryTrack.track.duration,
           };
         })


### PR DESCRIPTION
# Refactor Track Source Identifier to Support Multiple Source Types

### TL;DR

Updating the app to work after replacing `sourceIdentifier` field with source-specific fields (`sourceId`, `sourceUrl`, `artworkUrl`) to better handle different track sources.

### What changed?

- Modified the `PlaylistTrack` and `LibraryTrack` interfaces to replace the generic `sourceIdentifier` field with more specific fields:
  - `sourceId`: For YouTube and similar ID-based sources
  - `sourceUrl`: For SoundCloud and URL-based sources
  - `artworkUrl`: For storing track artwork URLs
- Added a new `getTrackIdentifier` method in `AudioController` that selects the appropriate identifier based on the track source
- Updated the track loading logic to use this new method when loading tracks
- Updated related code in library and playlist routers to use the new fields

