### PR TITLE
getting track data from sc on song add

### DIFF
--- a/src/app/_components/forms/AddSong.tsx
+++ b/src/app/_components/forms/AddSong.tsx
@@ -24,6 +24,7 @@ import { Input } from "~/components/ui/input";
 import { useForm } from "react-hook-form";
 import { Button } from "~/components/ui/button";
 import { MultiSelect } from "./MultiSelectCombo";
+import { getTrackData } from "~/lib/actions/getTrackData";
 
 interface FormData {
   externalLink: string;
@@ -54,13 +55,18 @@ export const AddSong = ({
     console.log(data);
   };
 
-  const handleLinkInput = (value: string) => {
+  const handleLinkInput = async (value: string) => {
     // TODO: make this more robust, proper checking and validation
+    const trackData = await getTrackData(value);
     form.setValue("externalLink", value);
     form.setValue(
       "source",
       value.includes("soundcloud") ? "soundcloud" : "youtube",
     );
+    form.setValue("title", trackData.title);
+    form.setValue("artist", [trackData.artist]);
+
+    console.log(trackData);
   };
 
   const handleOpenChange = (open: boolean) => {
@@ -99,7 +105,7 @@ export const AddSong = ({
                       placeholder="Link"
                       onChange={(e) => {
                         field.onChange(e);
-                        handleLinkInput(e.target.value);
+                        void handleLinkInput(e.target.value);
                       }}
                     />
                   </FormControl>

--- a/src/lib/actions/getTrackData.ts
+++ b/src/lib/actions/getTrackData.ts
@@ -1,0 +1,107 @@
+"use server";
+
+interface SoundCloudResolveResponse {
+  title: string;
+  duration: number;
+  artwork_url: string;
+  id: number;
+  user: {
+    username: string;
+  };
+}
+
+export interface TrackData {
+  title: string;
+  artist: string;
+  album: string;
+  duration: number;
+  artworkUrl: string;
+  sourceUrl: string;
+  sourceId: string;
+}
+
+export async function getTrackData(url: string): Promise<TrackData> {
+  const source = url.includes("soundcloud") ? "soundcloud" : "youtube";
+
+  try {
+    if (source === "soundcloud") {
+      return await fetchSoundCloudMetadata(url);
+    } else {
+      return await fetchYouTubeMetadata(url);
+    }
+  } catch (error) {
+    console.error(error);
+    throw new Error("Failed to get track data");
+  }
+}
+
+async function fetchSoundCloudMetadata(url: string) {
+  const clientId = process.env.SC_CLIENT_ID;
+  const clientSecret = process.env.SC_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    throw new Error("SoundCloud env variables not found");
+  }
+
+  // access token
+  const tokenResponse = await fetch("https://api.soundcloud.com/oauth2/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+
+  if (!tokenResponse.ok) {
+    const errorText = await tokenResponse.text();
+    console.log("Token error:", errorText);
+    throw new Error(`Failed to get access token: ${errorText}`);
+  }
+
+  const tokenData = (await tokenResponse.json()) as { access_token: string };
+  const accessToken = tokenData.access_token;
+
+  const apiUrl = `https://api.soundcloud.com/resolve.json?url=${encodeURIComponent(url)}`;
+
+  const res = await fetch(apiUrl, {
+    headers: {
+      Authorization: `OAuth ${accessToken}`,
+    },
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    console.log("Error response:", errorText);
+    throw new Error(
+      `SoundCloud API error: ${res.status} ${res.statusText} - ${errorText}`,
+    );
+  }
+
+  const data = (await res.json()) as SoundCloudResolveResponse;
+
+  return {
+    title: data.title,
+    artist: data.user?.username || "",
+    album: "",
+    duration: data.duration,
+    artworkUrl: data.artwork_url || "",
+    sourceUrl: url,
+    sourceId: data.id.toString(),
+  };
+}
+
+async function fetchYouTubeMetadata(url: string) {
+  return {
+    title: "",
+    artist: "",
+    album: "",
+    duration: 0,
+    artworkUrl: "",
+    sourceUrl: url,
+    sourceId: "",
+  };
+}


### PR DESCRIPTION
### TL;DR

Added automatic track metadata fetching when adding songs via URL

### What changed?

- Created a new server action `getTrackData` that fetches metadata from SoundCloud API
- Integrated this functionality into the AddSong form component to auto-populate title and artist fields
- Implemented SoundCloud API authentication using client credentials flow
- Added placeholder for YouTube metadata fetching (to be implemented later)

