### PR TITLE
artists api route

### DIFF
--- a/src/app/_components/forms/AddSong.tsx
+++ b/src/app/_components/forms/AddSong.tsx
@@ -25,6 +25,8 @@ import { useForm } from "react-hook-form";
 import { Button } from "~/components/ui/button";
 import { MultiSelect } from "./MultiSelectCombo";
 import { getTrackData } from "~/lib/actions/getTrackData";
+import { useState, useEffect } from "react";
+import { api } from "~/trpc/react";
 
 interface FormData {
   externalLink: string;
@@ -41,6 +43,13 @@ export const AddSong = ({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) => {
+  const { data = [] } = api.artists.getAll.useQuery();
+  const [artists, setArtists] = useState(data);
+
+  useEffect(() => {
+    setArtists(data);
+  }, [data]);
+
   const form = useForm<FormData>({
     defaultValues: {
       externalLink: "",
@@ -65,21 +74,16 @@ export const AddSong = ({
     );
     form.setValue("title", trackData.title);
     form.setValue("artist", [trackData.artist]);
-
-    console.log(trackData);
+    setArtists([
+      ...artists,
+      { value: trackData.artist, label: trackData.artist },
+    ]);
   };
 
   const handleOpenChange = (open: boolean) => {
     onOpenChange(open);
     form.reset();
   };
-
-  const artists = [
-    { value: "evenS", label: "evenS" },
-    { value: "janu4ryss", label: "janu4ryss" },
-    { value: "nujabes", label: "nujabes" },
-    { value: "9lives", label: "9lives" },
-  ];
 
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>

--- a/src/app/_components/forms/MultiSelectCombo.tsx
+++ b/src/app/_components/forms/MultiSelectCombo.tsx
@@ -48,6 +48,7 @@ export function MultiSelect({
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [internalOptions, setInternalOptions] = useState(initialOptions);
+  console.log(internalOptions);
 
   const handleSelect = useCallback(
     (value: string) => {

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -2,6 +2,7 @@ import { postRouter } from "~/server/api/routers/post";
 import { playlistsRouter } from "~/server/api/routers/playlists";
 import { userRouter } from "~/server/api/routers/user";
 import { libraryRouter } from "~/server/api/routers/library";
+import { artistsRouter } from "~/server/api/routers/artists";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -14,6 +15,7 @@ export const appRouter = createTRPCRouter({
   playlists: playlistsRouter,
   user: userRouter,
   library: libraryRouter,
+  artists: artistsRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/artists.ts
+++ b/src/server/api/routers/artists.ts
@@ -1,0 +1,25 @@
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+
+export const artistsRouter = createTRPCRouter({
+  getAll: protectedProcedure.query(async ({ ctx }) => {
+    const artists = await ctx.db.artist.findMany({
+      where: {
+        libraryTracks: {
+          some: {
+            libraryTrack: {
+              userId: ctx.user.id,
+            },
+          },
+        },
+      },
+      orderBy: {
+        name: "asc",
+      },
+    });
+
+    return artists.map((artist) => ({
+      value: artist.name,
+      label: artist.name,
+    }));
+  }),
+});


### PR DESCRIPTION
### TL;DR

Added dynamic artist fetching for the Add Song form, replacing hardcoded artist options.

### What changed?

- Created a new `artistsRouter` in the tRPC API to fetch artists from the database
- Added the artists router to the API root
- Modified the `AddSong` component to:
  - Fetch artists dynamically using the new API endpoint
  - Maintain artists state with useState and useEffect
  - Add newly discovered artists from track data to the artists list
- Removed hardcoded artist options from the AddSong component

