### PR TITLE
updated stepper form for adding track

### DIFF
--- a/src/app/_components/forms/AddSong.tsx
+++ b/src/app/_components/forms/AddSong.tsx
@@ -1,40 +1,16 @@
+"use client";
+
+import { useState } from "react";
 import {
   Sheet,
   SheetContent,
-  SheetDescription,
-  SheetHeader,
   SheetTitle,
-  SheetFooter,
+  SheetDescription,
 } from "~/components/ui/sheet";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-} from "~/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/ui/select";
-import { Input } from "~/components/ui/input";
-import { useForm } from "react-hook-form";
-import { Button } from "~/components/ui/button";
-import { MultiSelect } from "./MultiSelectCombo";
-import { getTrackData } from "~/lib/actions/getTrackData";
-import { useState, useEffect } from "react";
+import { LinkStep } from "./LinkStep";
+import { TrackForm } from "./TrackForm";
 import { api } from "~/trpc/react";
-
-interface FormData {
-  externalLink: string;
-  source: "soundcloud" | "youtube" | "";
-  title: string;
-  artist: string[];
-  album: string;
-}
+import { type TrackData } from "~/lib/actions/getTrackData";
 
 export const AddSong = ({
   open,
@@ -43,158 +19,55 @@ export const AddSong = ({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) => {
-  const { data = [] } = api.artists.getAll.useQuery();
-  const [artists, setArtists] = useState(data);
+  const { data } = api.artists.getAll.useQuery();
+  const [currentStep, setCurrentStep] = useState(1);
+  const [fetchedData, setFetchedData] = useState<TrackData | null>(null);
 
-  useEffect(() => {
-    setArtists(data);
-  }, [data]);
-
-  const form = useForm<FormData>({
-    defaultValues: {
-      externalLink: "",
-      source: "",
-      title: "",
-      artist: [],
-      album: "",
-    },
-  });
-
-  const handleSubmit = (data: FormData) => {
-    console.log(data);
+  const handleStep1Next = (data: TrackData) => {
+    setFetchedData(data);
+    setCurrentStep(2);
   };
 
-  const handleLinkInput = async (value: string) => {
-    // TODO: make this more robust, proper checking and validation
-    const trackData = await getTrackData(value);
-    form.setValue("externalLink", value);
-    form.setValue(
-      "source",
-      value.includes("soundcloud") ? "soundcloud" : "youtube",
-    );
-    form.setValue("title", trackData.title);
-    form.setValue("artist", [trackData.artist]);
-    setArtists([
-      ...artists,
-      { value: trackData.artist, label: trackData.artist },
-    ]);
+  const handleStep2Submit = (data: any) => {
+    console.log("Final form data:", data);
+    // TODO: Implement actual submission logic
+    onOpenChange(false);
   };
 
+  const handleBack = () => {
+    setCurrentStep(1);
+    setFetchedData(null);
+  };
+
+  // Reset state when sheet closes
   const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setCurrentStep(1);
+      setFetchedData(null);
+    }
     onOpenChange(open);
-    form.reset();
   };
 
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>
       <SheetContent>
-        <SheetHeader>
+        <div className="hidden">
           <SheetTitle>Add Song</SheetTitle>
-        </SheetHeader>
-        <SheetDescription>Add a song to your library</SheetDescription>
-        <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(handleSubmit)}
-            className="space-y-4"
-          >
-            <FormField
-              control={form.control}
-              name="externalLink"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Link</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder="Link"
-                      onChange={(e) => {
-                        field.onChange(e);
-                        void handleLinkInput(e.target.value);
-                      }}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="source"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Source</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    value={field.value}
-                    disabled={true}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select Source" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="soundcloud">SoundCloud</SelectItem>
-                      <SelectItem value="youtube">YouTube</SelectItem>
-                      {/* <SelectItem value="spotify">Spotify</SelectItem> */}
-                      {/* <SelectItem value="local">Local</SelectItem> */}
-                    </SelectContent>
-                  </Select>
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="title"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Title</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="Title" />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="artist"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Artist</FormLabel>
-                  <FormControl>
-                    <MultiSelect
-                      options={artists}
-                      selected={field.value}
-                      onChange={field.onChange}
-                      placeholder="Artist"
-                      allowAdd={true}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="album"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Album</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="Album" />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-          </form>
-        </Form>
-
-        <SheetFooter>
-          <Button type="submit" onClick={form.handleSubmit(handleSubmit)}>
-            Add Song
-          </Button>
-          <Button type="button" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-        </SheetFooter>
+          <SheetDescription>Add a new song to your library.</SheetDescription>
+        </div>
+        {currentStep === 1 && <LinkStep onNext={handleStep1Next} />}
+        {currentStep === 2 && fetchedData && (
+          <TrackForm
+            initialData={fetchedData}
+            onSubmit={handleStep2Submit}
+            onBack={handleBack}
+            mode="add"
+            artists={[
+              { value: fetchedData.artist, label: fetchedData.artist },
+              ...(data ?? []),
+            ]}
+          />
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/src/app/_components/forms/LinkStep.tsx
+++ b/src/app/_components/forms/LinkStep.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { Input } from "~/components/ui/input";
+import { Button } from "~/components/ui/button";
+import { getTrackData, type TrackData } from "~/lib/actions/getTrackData";
+
+interface LinkStepProps {
+  onNext: (data: TrackData) => void;
+}
+
+export const LinkStep = ({ onNext }: LinkStepProps) => {
+  const [link, setLink] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLinkSubmit = async () => {
+    setIsLoading(true);
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const trackData = await getTrackData(link);
+      onNext(trackData);
+    } catch (err) {
+      // TODO: better error handling, show error then reset
+      setError(
+        "Failed to fetch track data. Please check the link and try again.",
+      );
+      console.error("Error fetching track data:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="mt-10">
+      {isLoading ? (
+        // TODO
+        <p>Loading...</p>
+      ) : (
+        <div>
+          <Input value={link} onChange={(e) => setLink(e.target.value)} />
+          <Button onClick={handleLinkSubmit}>Next</Button>
+          {error && <p className="text-red-500">{error}</p>}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/_components/forms/MultiSelectCombo.tsx
+++ b/src/app/_components/forms/MultiSelectCombo.tsx
@@ -48,7 +48,6 @@ export function MultiSelect({
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [internalOptions, setInternalOptions] = useState(initialOptions);
-  console.log(internalOptions);
 
   const handleSelect = useCallback(
     (value: string) => {

--- a/src/app/_components/forms/TrackForm.tsx
+++ b/src/app/_components/forms/TrackForm.tsx
@@ -1,0 +1,123 @@
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "~/components/ui/form";
+import { Input } from "~/components/ui/input";
+import { useForm } from "react-hook-form";
+import { MultiSelect } from "./MultiSelectCombo";
+import { type TrackData } from "~/lib/actions/getTrackData";
+import { Button } from "~/components/ui/button";
+
+interface FormData {
+  externalLink: string;
+  source: "soundcloud" | "youtube";
+  sourceId: string;
+  sourceUrl: string;
+  duration: number;
+  artworkUrl: string;
+  title: string;
+  artist: string[];
+  album: string;
+}
+
+export const TrackForm = ({
+  initialData,
+  onSubmit,
+  onBack,
+  mode,
+  artists,
+}: {
+  initialData: TrackData;
+  onSubmit: (data: FormData) => void;
+  onBack: () => void;
+  mode: "add" | "edit";
+  artists: { value: string; label: string }[];
+}) => {
+  const form = useForm<FormData>({
+    defaultValues: {
+      externalLink: initialData.sourceUrl,
+      sourceId: initialData.sourceId,
+      source: initialData.source,
+      title: initialData.title,
+      artist: initialData.artist ? [initialData.artist] : [],
+      album: "",
+      duration: initialData.duration,
+      artworkUrl: initialData.artworkUrl,
+    },
+  });
+
+  const handleSubmit = (data: FormData) => {
+    console.log(data);
+    // onSubmit({
+    //   ...data,
+    //   sourceUrl: initialData.sourceUrl,
+    //   sourceId: initialData.sourceId,
+    // });
+  };
+
+  return (
+    <div className="mt-10">
+      {/* TODO: maybe use, don't always know where the image is coming from */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        className="h-30 w-30"
+        src={initialData.artworkUrl}
+        alt={initialData.title}
+      />
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="title"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title</FormLabel>
+                <FormControl>
+                  <Input {...field} placeholder="Title" />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="artist"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Artist</FormLabel>
+                <FormControl>
+                  <MultiSelect
+                    options={artists}
+                    selected={field.value}
+                    onChange={field.onChange}
+                    placeholder="Artist"
+                    allowAdd={true}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="album"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Album</FormLabel>
+                <FormControl>
+                  <Input {...field} placeholder="Album" />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <p>Source: {initialData.source}</p>
+          <Button type="submit">Add Song</Button>
+          <Button type="button" onClick={onBack}>
+            Back
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+};

--- a/src/lib/actions/getTrackData.ts
+++ b/src/lib/actions/getTrackData.ts
@@ -18,6 +18,7 @@ export interface TrackData {
   artworkUrl: string;
   sourceUrl: string;
   sourceId: string;
+  source: "soundcloud" | "youtube";
 }
 
 export async function getTrackData(url: string): Promise<TrackData> {
@@ -91,6 +92,7 @@ async function fetchSoundCloudMetadata(url: string) {
     artworkUrl: data.artwork_url || "",
     sourceUrl: url,
     sourceId: data.id.toString(),
+    source: "soundcloud" as const,
   };
 }
 
@@ -103,5 +105,6 @@ async function fetchYouTubeMetadata(url: string) {
     artworkUrl: "",
     sourceUrl: url,
     sourceId: "",
+    source: "youtube" as const,
   };
 }


### PR DESCRIPTION
### TL;DR

Refactored the song addition flow into a multi-step process with improved UI and data handling.

### What changed?

- Split the song addition process into two distinct steps:
  1. A `LinkStep` component where users enter a link to a song
  2. A `TrackForm` component that displays fetched metadata and allows editing
- Created reusable components for better code organization:
  - `LinkStep.tsx` for handling link input and data fetching
  - `TrackForm.tsx` for displaying and editing track metadata
- Enhanced the `getTrackData` function to include source information
- Improved state management with React hooks to handle the multi-step flow
- Added proper error handling for failed track data fetches
- Implemented a back button to allow users to return to the link input step



This change also improves code maintainability by separating concerns into dedicated components and establishing a clearer data flow.