### PR TITLE
dont render context menu if not signed in

### DIFF
--- a/src/app/_components/ContextMenu.tsx
+++ b/src/app/_components/ContextMenu.tsx
@@ -9,13 +9,18 @@ import {
 } from "~/components/ui/context-menu";
 import { AddSong } from "~/app/_components/forms/AddSong";
 
-import { SignOutButton } from "@clerk/nextjs";
+import { SignOutButton, useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 export const GlobalContextMenu = () => {
   const router = useRouter();
+  const { isSignedIn } = useUser();
   const [addSongOpen, setAddSongOpen] = useState(false);
+
+  if (!isSignedIn) {
+    return null;
+  }
 
   const handlePlaylists = () => {
     router.push("/playlists");


### PR DESCRIPTION
### TL;DR

Added a check to hide the context menu for users who are not signed in.

### What changed?

- Imported the `useUser` hook from Clerk
- Added a check to determine if the user is signed in
- Added conditional rendering to return `null` when the user is not signed in, preventing the context menu from displaying
