### PR TITLE
adding a song backend and form submission

### DIFF
--- a/src/app/_components/ContextMenu.tsx
+++ b/src/app/_components/ContextMenu.tsx
@@ -7,7 +7,7 @@ import {
   ContextMenuTrigger,
   ContextMenuSeparator,
 } from "~/components/ui/context-menu";
-import { AddSong } from "~/app/_components/forms/AddSong";
+import { AddTrack } from "~/app/_components/forms/AddTrack";
 
 import { SignOutButton, useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
@@ -52,7 +52,7 @@ export const GlobalContextMenu = () => {
         </ContextMenuContent>
       </ContextMenu>
 
-      <AddSong open={addSongOpen} onOpenChange={setAddSongOpen} />
+      <AddTrack open={addSongOpen} onOpenChange={setAddSongOpen} />
     </>
   );
 };

--- a/src/app/_components/forms/AddTrack.tsx
+++ b/src/app/_components/forms/AddTrack.tsx
@@ -11,8 +11,9 @@ import { LinkStep } from "./LinkStep";
 import { TrackForm } from "./TrackForm";
 import { api } from "~/trpc/react";
 import { type TrackData } from "~/lib/actions/getTrackData";
+import { type AddTrackFormData } from "./TrackForm";
 
-export const AddSong = ({
+export const AddTrack = ({
   open,
   onOpenChange,
 }: {
@@ -23,15 +24,36 @@ export const AddSong = ({
   const [currentStep, setCurrentStep] = useState(1);
   const [fetchedData, setFetchedData] = useState<TrackData | null>(null);
 
+  const addTrackMutation = api.tracks.addTrack.useMutation({
+    //TODO: toast
+    onSuccess: () => {
+      setCurrentStep(1);
+      setFetchedData(null);
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+
   const handleStep1Next = (data: TrackData) => {
     setFetchedData(data);
     setCurrentStep(2);
   };
 
-  const handleStep2Submit = (data: any) => {
-    console.log("Final form data:", data);
-    // TODO: Implement actual submission logic
-    onOpenChange(false);
+  const handleStep2Submit = (data: AddTrackFormData) => {
+    const preprocessedData = {
+      title: data.title,
+      artist: data.artist.filter((name) => name.trim() !== ""), // Remove empty artist names
+      album: data.album?.trim() || undefined,
+      source: data.source,
+      sourceId: data.sourceId,
+      sourceUrl: data.sourceUrl,
+      artworkUrl: data.artworkUrl || undefined,
+      duration: data.duration || undefined,
+    };
+
+    addTrackMutation.mutate(preprocessedData);
   };
 
   const handleBack = () => {

--- a/src/app/_components/forms/TrackForm.tsx
+++ b/src/app/_components/forms/TrackForm.tsx
@@ -11,16 +11,15 @@ import { MultiSelect } from "./MultiSelectCombo";
 import { type TrackData } from "~/lib/actions/getTrackData";
 import { Button } from "~/components/ui/button";
 
-interface FormData {
-  externalLink: string;
+export interface AddTrackFormData {
+  album: string;
+  artist: string[];
+  artworkUrl: string;
+  duration: number;
   source: "soundcloud" | "youtube";
   sourceId: string;
   sourceUrl: string;
-  duration: number;
-  artworkUrl: string;
   title: string;
-  artist: string[];
-  album: string;
 }
 
 export const TrackForm = ({
@@ -31,31 +30,53 @@ export const TrackForm = ({
   artists,
 }: {
   initialData: TrackData;
-  onSubmit: (data: FormData) => void;
+  onSubmit: (data: AddTrackFormData) => void;
   onBack: () => void;
   mode: "add" | "edit";
   artists: { value: string; label: string }[];
 }) => {
-  const form = useForm<FormData>({
+  const form = useForm<AddTrackFormData>({
     defaultValues: {
-      externalLink: initialData.sourceUrl,
-      sourceId: initialData.sourceId,
-      source: initialData.source,
-      title: initialData.title,
-      artist: initialData.artist ? [initialData.artist] : [],
       album: "",
-      duration: initialData.duration,
+      artist: initialData.artist ? [initialData.artist] : [],
       artworkUrl: initialData.artworkUrl,
+      duration: initialData.duration,
+      source: initialData.source,
+      sourceId: initialData.sourceId,
+      sourceUrl: initialData.sourceUrl,
+      title: initialData.title,
     },
   });
 
-  const handleSubmit = (data: FormData) => {
-    console.log(data);
-    // onSubmit({
-    //   ...data,
-    //   sourceUrl: initialData.sourceUrl,
-    //   sourceId: initialData.sourceId,
-    // });
+  const handleSubmit = (data: AddTrackFormData) => {
+    //TODO: form validation
+    if (!data.title.trim()) {
+      alert("Title is required");
+      return;
+    }
+
+    if (!data.artist.length || data.artist.every((name) => !name.trim())) {
+      alert("At least one artist is required");
+      return;
+    }
+
+    if (!data.source || !data.sourceId || !data.sourceUrl) {
+      alert(
+        "Source information is missing. Please try fetching the track data again.",
+      );
+      return;
+    }
+
+    const validArtists = data.artist.filter((name) => name.trim() !== "");
+    if (validArtists.length === 0) {
+      alert("At least one valid artist name is required");
+      return;
+    }
+
+    onSubmit({
+      ...data,
+      artist: validArtists,
+    });
   };
 
   return (

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -3,6 +3,7 @@ import { playlistsRouter } from "~/server/api/routers/playlists";
 import { userRouter } from "~/server/api/routers/user";
 import { libraryRouter } from "~/server/api/routers/library";
 import { artistsRouter } from "~/server/api/routers/artists";
+import { tracksRouter } from "~/server/api/routers/tracks";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -16,6 +17,7 @@ export const appRouter = createTRPCRouter({
   user: userRouter,
   library: libraryRouter,
   artists: artistsRouter,
+  tracks: tracksRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/tracks.ts
+++ b/src/server/api/routers/tracks.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { type SongSource } from "@prisma/client";
+
+export const tracksRouter = createTRPCRouter({
+  addTrack: protectedProcedure
+    .input(
+      z.object({
+        album: z.string().optional(),
+        artist: z
+          .array(z.string().min(1, "Artist name cannot be empty"))
+          .min(1, "At least one artist is required"),
+        artworkUrl: z.string().optional(),
+        duration: z.number().optional(),
+        source: z.string(),
+        sourceId: z.string(),
+        sourceUrl: z.string(),
+        title: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.user.id;
+
+      return await ctx.db.$transaction(async (tx) => {
+        // base track
+        let track = await tx.track.findUnique({
+          where: {
+            source_sourceId: {
+              source: input.source as SongSource,
+              sourceId: input.sourceId,
+            },
+          },
+        });
+
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        if (!track) {
+          track = await tx.track.create({
+            data: {
+              source: input.source as SongSource,
+              sourceId: input.sourceId,
+              sourceUrl: input.sourceUrl,
+              artworkUrl: input.artworkUrl,
+              duration: input.duration,
+            },
+          });
+        }
+
+        // artists
+        const artistPromises = input.artist.map(async (artistName) => {
+          let artist = await tx.artist.findFirst({
+            where: {
+              name: artistName,
+            },
+          });
+
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          if (!artist) {
+            artist = await tx.artist.create({
+              data: {
+                name: artistName,
+              },
+            });
+          }
+
+          return artist;
+        });
+        const artists = await Promise.all(artistPromises);
+
+        // album
+        let album = await tx.album.findFirst({
+          where: {
+            name: input.album,
+          },
+        });
+
+        if (!album && input.album) {
+          album = await tx.album.create({
+            data: {
+              name: input.album,
+            },
+          });
+        }
+
+        // library track
+        const libraryTrack = await tx.libraryTrack.create({
+          data: {
+            title: input.title,
+            albumId: album?.id ?? undefined,
+            trackId: track.id,
+            userId,
+          },
+        });
+
+        // connect artists
+        await tx.libraryTrackArtist.createMany({
+          data: artists.map((artist) => ({
+            libraryTrackId: libraryTrack.id,
+            artistId: artist.id,
+          })),
+        });
+
+        return libraryTrack;
+      });
+    }),
+});


### PR DESCRIPTION
### TL;DR

Renamed AddSong to AddTrack and implemented track submission functionality.

### What changed?

- Renamed `AddSong` component to `AddTrack` for consistency
- Implemented the track submission logic in the form
- Added form validation for required fields
- Created a new `tracks` router with an `addTrack` mutation
- Connected the form to the API to save tracks to the database
- Added transaction handling to ensure data integrity when creating tracks, artists, and albums

