### PR TITLE
confirmation modal

### DIFF
--- a/src/app/_components/ConfirmationDialog.tsx
+++ b/src/app/_components/ConfirmationDialog.tsx
@@ -1,0 +1,34 @@
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+} from "~/components/ui/dialog";
+
+export const ConfirmationDialog = ({
+  text,
+  onConfirm,
+  open,
+  onOpenChange,
+}: {
+  text: string;
+  onConfirm: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>{text}</DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button onClick={onConfirm}>Confirm</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/app/playlist/[id]/PlaylistHeader.tsx
+++ b/src/app/playlist/[id]/PlaylistHeader.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { ConfirmationDialog } from "~/app/_components/ConfirmationDialog";
 
 export const PlaylistHeader = ({
   playlistId,
@@ -15,6 +16,7 @@ export const PlaylistHeader = ({
   const utils = api.useUtils();
   const router = useRouter();
   const [hovered, setHovered] = useState(false);
+  const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
 
   const deletePlaylistMutation = api.playlists.deletePlaylist.useMutation({
     onSuccess: async () => {
@@ -27,21 +29,29 @@ export const PlaylistHeader = ({
   });
 
   return (
-    <div
-      className="flex w-120 items-center justify-between"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-    >
-      <h1 className="mt-7">{playlistName}</h1>
-      {hovered && (
-        <Button
-          size="icon"
-          className="rounded-full"
-          onClick={() => deletePlaylistMutation.mutate({ id: playlistId })}
-        >
-          <Trash2 />
-        </Button>
-      )}
-    </div>
+    <>
+      <div
+        className="flex w-120 items-center justify-between"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        <h1 className="mt-7">{playlistName}</h1>
+        {hovered && (
+          <Button
+            size="icon"
+            className="rounded-full"
+            onClick={() => setConfirmationDialogOpen(true)}
+          >
+            <Trash2 />
+          </Button>
+        )}
+      </div>
+      <ConfirmationDialog
+        text="Are you sure you want to delete this playlist?"
+        onConfirm={() => deletePlaylistMutation.mutate({ id: playlistId })}
+        open={confirmationDialogOpen}
+        onOpenChange={setConfirmationDialogOpen}
+      />
+    </>
   );
 };


### PR DESCRIPTION
### TL;DR

Added a confirmation dialog when deleting playlists to prevent accidental deletions.

### What changed?

- Created a new reusable `ConfirmationDialog` component that displays a dialog with confirm/cancel options
- Integrated the confirmation dialog into the playlist deletion flow
- Modified the `PlaylistHeader` component to show the confirmation dialog before executing the delete mutation


### Why make this change?

This change improves the user experience by preventing accidental playlist deletions. Previously, clicking the delete button would immediately remove the playlist without confirmation, which could lead to data loss if clicked unintentionally.