### PR TITLE
edit a playlist name

### DIFF
--- a/src/app/playlist/[id]/PlaylistHeader.tsx
+++ b/src/app/playlist/[id]/PlaylistHeader.tsx
@@ -2,9 +2,10 @@
 import { api } from "~/trpc/react";
 import { useState } from "react";
 import { Button } from "~/components/ui/button";
-import { Trash2 } from "lucide-react";
+import { Trash2, Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { ConfirmationDialog } from "~/app/_components/ConfirmationDialog";
+import { Input } from "~/components/ui/input";
 
 export const PlaylistHeader = ({
   playlistId,
@@ -16,7 +17,18 @@ export const PlaylistHeader = ({
   const utils = api.useUtils();
   const router = useRouter();
   const [hovered, setHovered] = useState(false);
+  const [currentPlaylistName, setCurrentPlaylistName] = useState(playlistName);
+  const [isEditing, setIsEditing] = useState(false);
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
+
+  const updatePlaylistMutation = api.playlists.updatePlaylist.useMutation({
+    onSuccess: async () => {
+      await utils.playlists.getAll.invalidate();
+    },
+    onError: () => {
+      //TODO: toast
+    },
+  });
 
   const deletePlaylistMutation = api.playlists.deletePlaylist.useMutation({
     onSuccess: async () => {
@@ -28,6 +40,12 @@ export const PlaylistHeader = ({
     },
   });
 
+  const handleUpdatePlaylistName = (name: string) => {
+    updatePlaylistMutation.mutate({ id: playlistId, name: name });
+    setCurrentPlaylistName(name);
+    setIsEditing(false);
+  };
+
   return (
     <>
       <div
@@ -35,15 +53,31 @@ export const PlaylistHeader = ({
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
-        <h1 className="mt-7">{playlistName}</h1>
-        {hovered && (
-          <Button
-            size="icon"
-            className="rounded-full"
-            onClick={() => setConfirmationDialogOpen(true)}
-          >
-            <Trash2 />
-          </Button>
+        {isEditing ? (
+          <Input
+            defaultValue={currentPlaylistName}
+            onBlur={(e) => handleUpdatePlaylistName(e.target.value)}
+          />
+        ) : (
+          <h1 className="mt-7">{currentPlaylistName}</h1>
+        )}
+        {hovered && !isEditing && (
+          <div>
+            <Button
+              size="icon"
+              className="rounded-full"
+              onClick={() => setIsEditing(true)}
+            >
+              <Pencil />
+            </Button>
+            <Button
+              size="icon"
+              className="rounded-full"
+              onClick={() => setConfirmationDialogOpen(true)}
+            >
+              <Trash2 />
+            </Button>
+          </div>
         )}
       </div>
       <ConfirmationDialog

--- a/src/server/api/routers/playlists.ts
+++ b/src/server/api/routers/playlists.ts
@@ -13,76 +13,73 @@ export const playlistsRouter = createTRPCRouter({
       },
     });
   }),
-  getById: protectedProcedure
-    .input(z.object({ id: z.number() }))
-    .query(
-      async ({
-        ctx,
-        input,
-      }): Promise<{
-        playlistEntries: PlaylistTrack[];
-        playlistName: string;
-        playlistId: number;
-      } | null> => {
-        const dbPlaylist = await ctx.db.playlist.findUnique({
-          where: {
-            id: input.id,
-            userId: ctx.user.id,
-          },
-          include: {
-            playlistEntries: {
-              include: {
-                libraryTrack: {
-                  include: {
-                    track: true,
-                    album: true,
-                    artists: {
-                      include: {
-                        artist: true,
-                      },
+  getById: protectedProcedure.input(z.object({ id: z.number() })).query(
+    async ({
+      ctx,
+      input,
+    }): Promise<{
+      playlistEntries: PlaylistTrack[];
+      playlistName: string;
+      playlistId: number;
+    } | null> => {
+      const dbPlaylist = await ctx.db.playlist.findUnique({
+        where: {
+          id: input.id,
+          userId: ctx.user.id,
+        },
+        include: {
+          playlistEntries: {
+            include: {
+              libraryTrack: {
+                include: {
+                  track: true,
+                  album: true,
+                  artists: {
+                    include: {
+                      artist: true,
                     },
                   },
                 },
               },
             },
           },
-        });
+        },
+      });
 
-        if (!dbPlaylist) return null;
+      if (!dbPlaylist) return null;
 
-        const flattenedPlaylist = dbPlaylist.playlistEntries
-          .map((entry) => {
-            return {
-              playlistId: entry.playlistId,
-              playlistName: dbPlaylist.name,
-              trackId: entry.libraryTrackId,
-              position: entry.position,
-              album: entry.libraryTrack.album?.name ?? null,
-              albumId: entry.libraryTrack.albumId,
-              artists: entry.libraryTrack.artists.map((artist) => {
-                return {
-                  artistId: artist.artistId,
-                  artistName: artist.artist.name,
-                };
-              }),
-              title: entry.libraryTrack.title,
-              source: entry.libraryTrack.track.source,
-              sourceId: entry.libraryTrack.track.sourceId,
-              sourceUrl: entry.libraryTrack.track.sourceUrl,
-              artworkUrl: entry.libraryTrack.track.artworkUrl,
-              duration: entry.libraryTrack.track.duration,
-            };
-          })
-          .sort((a, b) => a.position - b.position);
+      const flattenedPlaylist = dbPlaylist.playlistEntries
+        .map((entry) => {
+          return {
+            playlistId: entry.playlistId,
+            playlistName: dbPlaylist.name,
+            trackId: entry.libraryTrackId,
+            position: entry.position,
+            album: entry.libraryTrack.album?.name ?? null,
+            albumId: entry.libraryTrack.albumId,
+            artists: entry.libraryTrack.artists.map((artist) => {
+              return {
+                artistId: artist.artistId,
+                artistName: artist.artist.name,
+              };
+            }),
+            title: entry.libraryTrack.title,
+            source: entry.libraryTrack.track.source,
+            sourceId: entry.libraryTrack.track.sourceId,
+            sourceUrl: entry.libraryTrack.track.sourceUrl,
+            artworkUrl: entry.libraryTrack.track.artworkUrl,
+            duration: entry.libraryTrack.track.duration,
+          };
+        })
+        .sort((a, b) => a.position - b.position);
 
-        return {
-          playlistEntries: flattenedPlaylist,
-          playlistName: dbPlaylist.name,
-          playlistId: dbPlaylist.id,
-        };
-      },
-    ),
-
+      return {
+        playlistEntries: flattenedPlaylist,
+        playlistName: dbPlaylist.name,
+        playlistId: dbPlaylist.id,
+      };
+    },
+  ),
   addPlaylist: protectedProcedure
     .input(z.object({ name: z.string() }))
     .mutation(async ({ ctx, input }) => {
@@ -115,5 +112,23 @@ export const playlistsRouter = createTRPCRouter({
       });
 
       return { success: true };
+    }),
+  updatePlaylist: protectedProcedure
+    .input(z.object({ id: z.number(), name: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const playlist = await ctx.db.playlist.findUnique({
+        where: { id: input.id, userId: ctx.user.id },
+      });
+
+      if (!playlist) {
+        throw new Error("Playlist not found");
+      }
+
+      await ctx.db.playlist.update({
+        where: { id: input.id, userId: ctx.user.id },
+        data: { name: input.name },
+      });
+
+      return { name: input.name };
     }),
 });


### PR DESCRIPTION
### TL;DR

Added the ability to edit playlist names directly from the playlist view.

### What changed?

- Added an edit button with a pencil icon next to the delete button in the playlist header
- Implemented an inline editing experience where clicking the edit button replaces the playlist name with an input field
- Created a new TRPC mutation `updatePlaylist` in the playlists router to handle name updates
- Added state management for tracking editing mode and current playlist name


### Why make this change?

This improves the user experience by allowing users to rename playlists directly from the playlist view without having to navigate to a separate settings page. It follows standard UX patterns for inline editing and makes playlist management more intuitive.