### PR TITLE
playlist management on song controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@t3-oss/env-nextjs": "^0.12.0",
@@ -2253,6 +2254,70 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
+      "integrity": "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@t3-oss/env-nextjs": "^0.12.0",

--- a/src/app/_components/TrackOptions.tsx
+++ b/src/app/_components/TrackOptions.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Ellipsis } from "lucide-react";
 import {
   Popover,
@@ -5,19 +7,79 @@ import {
   PopoverContent,
 } from "~/components/ui/popover";
 import { EditTrack } from "./forms/EditTrack";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { Separator } from "~/components/ui/separator";
 import type { PlaylistTrack } from "./player/types/player";
+import { PlaylistSelector } from "./forms/PlaylistSelector";
+import { api } from "~/trpc/react";
+import { useRouter } from "next/navigation";
 
 export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
+  const utils = api.useUtils();
+  const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [selectedPlaylists, setSelectedPlaylists] = useState<number[]>([]);
+
+  const { data: trackPlaylists } = api.tracks.getTrackPlaylists.useQuery(
+    {
+      trackId: song.trackId,
+    },
+    {
+      enabled: popoverOpen,
+    },
+  );
+  const { data: playlists } = api.playlists.getAll.useQuery();
+  const formattedPlaylists = playlists?.map((playlist) => ({
+    value: playlist.id,
+    label: playlist.name,
+  }));
+
+  const updateTrackPlaylistsMutation =
+    api.playlists.updateTrackPlaylists.useMutation({
+      onSuccess: async () => {
+        await utils.tracks.getTrackPlaylists.invalidate({
+          trackId: song.trackId,
+        });
+        await utils.playlists.getAll.invalidate();
+        await utils.playlists.getById.invalidate({ id: song.playlistId });
+        router.refresh();
+      },
+      onError: (error) => {
+        console.error(error);
+      },
+    });
+
+  useEffect(() => {
+    if (trackPlaylists) {
+      setSelectedPlaylists(trackPlaylists);
+    }
+  }, [trackPlaylists]);
+
+  const handleUpdateTrackPlaylists = (playlistIds: number[]) => {
+    setSelectedPlaylists(playlistIds);
+    updateTrackPlaylistsMutation.mutate({
+      trackId: song.trackId,
+      playlistIds: playlistIds,
+    });
+  };
+
   return (
     <>
-      <Popover>
+      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
         <PopoverTrigger>
           <Ellipsis className="h-4 w-4" />
         </PopoverTrigger>
         <PopoverContent>
           <div onClick={() => setOpen(true)}>Edit</div>
+          <Separator />
+          <PlaylistSelector
+            options={formattedPlaylists ?? []}
+            selected={selectedPlaylists}
+            onChange={(selectedPlaylists) => {
+              handleUpdateTrackPlaylists(selectedPlaylists);
+            }}
+          />
         </PopoverContent>
       </Popover>
       {open && <EditTrack open={open} onOpenChange={setOpen} song={song} />}

--- a/src/app/_components/forms/PlaylistSelector.tsx
+++ b/src/app/_components/forms/PlaylistSelector.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { Check } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "~/components/ui/command";
+
+export type Option = {
+  value: number;
+  label: string;
+};
+
+interface PlaylistTrackSelectorProps {
+  options: Option[];
+  selected: number[];
+  onChange: (selected: number[]) => void;
+  placeholder?: string;
+  emptyText?: string;
+  className?: string;
+}
+
+export function PlaylistSelector({
+  options: initialOptions,
+  selected,
+  onChange,
+  placeholder = "Search",
+  emptyText = "No playlists found.",
+  className,
+}: PlaylistTrackSelectorProps) {
+  const [searchValue, setSearchValue] = useState("");
+
+  const handleSelect = useCallback(
+    (value: number) => {
+      const updatedSelected = selected.includes(value)
+        ? selected.filter((item) => item !== value)
+        : [...selected, value];
+      onChange(updatedSelected);
+    },
+    [selected, onChange],
+  );
+
+  // Filter options based on search
+  const filteredOptions = useMemo(() => {
+    if (!searchValue) return initialOptions;
+    return initialOptions.filter((option) =>
+      option.label.toLowerCase().includes(searchValue.toLowerCase()),
+    );
+  }, [initialOptions, searchValue]);
+
+  return (
+    <div className={cn("w-full", className)}>
+      <Command className="rounded-lg border" shouldFilter={false}>
+        <CommandInput
+          placeholder={placeholder}
+          className="h-9"
+          value={searchValue}
+          onValueChange={setSearchValue}
+        />
+        <CommandList>
+          <CommandEmpty>{emptyText}</CommandEmpty>
+          <CommandGroup>
+            {filteredOptions.map((option) => (
+              <CommandItem
+                key={option.value}
+                value={option.value.toString()}
+                onSelect={() => handleSelect(option.value)}
+              >
+                {option.label}
+                <Check
+                  className={cn(
+                    "ml-auto h-4 w-4",
+                    selected.includes(option.value)
+                      ? "opacity-100"
+                      : "opacity-0",
+                  )}
+                />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </div>
+  );
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "~/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/server/api/routers/playlists.ts
+++ b/src/server/api/routers/playlists.ts
@@ -131,4 +131,121 @@ export const playlistsRouter = createTRPCRouter({
 
       return { name: input.name };
     }),
+  updateTrackPlaylists: protectedProcedure
+    .input(z.object({ trackId: z.number(), playlistIds: z.array(z.number()) }))
+    .mutation(async ({ ctx, input }) => {
+      return await ctx.db.$transaction(async (tx) => {
+        const libraryTrack = await tx.libraryTrack.findUnique({
+          where: { id: input.trackId, userId: ctx.user.id },
+        });
+
+        if (!libraryTrack) {
+          throw new Error("Library track not found");
+        }
+
+        const currentlyInPlaylists = await tx.playlistEntry.findMany({
+          where: { libraryTrackId: input.trackId },
+        });
+
+        const currentPlaylistIds = new Set(
+          currentlyInPlaylists.map((entry) => entry.playlistId),
+        );
+        const newPlaylistIds = new Set(input.playlistIds);
+
+        const playlistsToAddTo = Array.from(newPlaylistIds).filter(
+          (id) => !currentPlaylistIds.has(id),
+        );
+        const playlistsToRemoveFrom = Array.from(currentPlaylistIds).filter(
+          (id) => !newPlaylistIds.has(id),
+        );
+
+        // adding track to playlists
+        for (const playlistId of playlistsToAddTo) {
+          const playlist = await tx.playlist.findUnique({
+            where: {
+              id: playlistId,
+              userId: ctx.user.id,
+            },
+          });
+
+          if (!playlist) {
+            throw new Error(`Playlist ${playlistId} not found`);
+          }
+
+          const maxPositionEntry = await tx.playlistEntry.findFirst({
+            where: {
+              playlistId: playlistId,
+            },
+            orderBy: {
+              position: "desc",
+            },
+          });
+
+          const newPosition = maxPositionEntry
+            ? maxPositionEntry.position + 1
+            : 0;
+
+          await tx.playlistEntry.create({
+            data: {
+              playlistId: playlistId,
+              libraryTrackId: libraryTrack.id,
+              position: newPosition,
+            },
+          });
+        }
+
+        // remove track from playlists
+        for (const playlistId of playlistsToRemoveFrom) {
+          const playlistEntry = await tx.playlistEntry.findFirst({
+            where: {
+              playlistId: playlistId,
+              libraryTrackId: libraryTrack.id,
+            },
+          });
+
+          if (!playlistEntry) {
+            throw new Error(
+              `Playlist entry for playlist ${playlistId} not found`,
+            );
+          }
+
+          const removedPosition = playlistEntry.position;
+
+          await tx.playlistEntry.delete({
+            where: {
+              playlistId_libraryTrackId: {
+                playlistId: playlistId,
+                libraryTrackId: libraryTrack.id,
+              },
+            },
+          });
+
+          // all entries in this playlist with position > removed position and decrement by 1
+          const entriesToShift = await tx.playlistEntry.findMany({
+            where: {
+              playlistId: playlistId,
+              position: {
+                gt: removedPosition,
+              },
+            },
+          });
+
+          for (const entry of entriesToShift) {
+            await tx.playlistEntry.update({
+              where: {
+                playlistId_libraryTrackId: {
+                  playlistId: entry.playlistId,
+                  libraryTrackId: entry.libraryTrackId,
+                },
+              },
+              data: {
+                position: entry.position - 1,
+              },
+            });
+          }
+        }
+
+        return { success: true };
+      });
+    }),
 });

--- a/src/server/api/routers/tracks.ts
+++ b/src/server/api/routers/tracks.ts
@@ -190,4 +190,28 @@ export const tracksRouter = createTRPCRouter({
         return updatedTrack;
       });
     }),
+  getTrackPlaylists: protectedProcedure
+    .input(z.object({ trackId: z.number() }))
+    .query(async ({ ctx, input }) => {
+      const libraryTrack = await ctx.db.libraryTrack.findUnique({
+        where: {
+          id: input.trackId,
+          userId: ctx.user.id,
+        },
+      });
+
+      if (!libraryTrack) {
+        throw new Error("Library track not found");
+      }
+
+      const playlistEntries = await ctx.db.playlistEntry.findMany({
+        where: {
+          libraryTrackId: input.trackId,
+        },
+      });
+
+      return playlistEntries.map((entry) => {
+        return entry.playlistId;
+      });
+    }),
 });


### PR DESCRIPTION
### TL;DR

Added playlist management functionality to track options, allowing users to add or remove tracks from multiple playlists.

### What changed?

- Implemented a `PlaylistSelector` component that allows multi-selection of playlists
- Enhanced the `TrackOptions` component to include playlist management functionality
- Added new TRPC endpoints:
  - `tracks.getTrackPlaylists` to fetch playlists containing a specific track
  - `playlists.updateTrackPlaylists` to add/remove a track from multiple playlists

### How to test?

1. Click on the ellipsis (options) button for any track
2. The popover now includes a playlist selector below the "Edit" option
3. Select or deselect playlists to add/remove the track from those playlists
4. Changes should be applied immediately and reflected in the UI
5. Verify that tracks appear in the correct playlists after making changes

### Why make this change?

This enhancement improves the user experience by allowing quick management of which playlists a track belongs to, without having to navigate to each playlist individually. It streamlines the workflow for organizing music collections and makes playlist management more efficient.