### PR TITLE
adding a track and playlists simultaneously

### DIFF
--- a/src/app/_components/forms/AddTrack.tsx
+++ b/src/app/_components/forms/AddTrack.tsx
@@ -12,6 +12,8 @@ import { TrackForm } from "./TrackForm";
 import { api } from "~/trpc/react";
 import { type TrackData } from "~/lib/actions/getTrackData";
 import { type AddTrackFormData } from "./TrackForm";
+import { PlaylistSelector } from "./PlaylistSelector";
+import { Button } from "~/components/ui/button";
 
 export const AddTrack = ({
   open,
@@ -20,15 +22,44 @@ export const AddTrack = ({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) => {
-  const { data } = api.artists.getAll.useQuery();
+  const utils = api.useUtils();
   const [currentStep, setCurrentStep] = useState(1);
   const [fetchedData, setFetchedData] = useState<TrackData | null>(null);
+  const [selectedPlaylists, setSelectedPlaylists] = useState<number[]>([]);
+  const { data: artists } = api.artists.getAll.useQuery();
+
+  const { data: playlists } = api.playlists.getAll.useQuery();
+  const formattedPlaylists = playlists?.map((playlist) => ({
+    value: playlist.id,
+    label: playlist.name,
+  }));
+
+  const updatePlaylistsMutation =
+    api.playlists.updateTrackPlaylists.useMutation({
+      onSuccess: async () => {
+        await utils.playlists.getAll.invalidate();
+        for (const playlistId of selectedPlaylists) {
+          await utils.playlists.getById.invalidate({ id: playlistId });
+        }
+      },
+      onError: (error) => {
+        console.error(error);
+      },
+    });
 
   const addTrackMutation = api.tracks.addTrack.useMutation({
     //TODO: toast
-    onSuccess: () => {
+    onSuccess: (libraryTrack) => {
+      if (selectedPlaylists.length > 0) {
+        updatePlaylistsMutation.mutate({
+          trackId: libraryTrack.id,
+          playlistIds: selectedPlaylists,
+        });
+      }
+
       setCurrentStep(1);
       setFetchedData(null);
+      setSelectedPlaylists([]);
       onOpenChange(false);
     },
     onError: (error) => {
@@ -59,6 +90,7 @@ export const AddTrack = ({
   const handleBack = () => {
     setCurrentStep(1);
     setFetchedData(null);
+    setSelectedPlaylists([]);
   };
 
   // Reset state when sheet closes
@@ -66,6 +98,7 @@ export const AddTrack = ({
     if (!open) {
       setCurrentStep(1);
       setFetchedData(null);
+      setSelectedPlaylists([]);
     }
     onOpenChange(open);
   };
@@ -79,19 +112,30 @@ export const AddTrack = ({
         </div>
         {currentStep === 1 && <LinkStep onNext={handleStep1Next} />}
         {currentStep === 2 && fetchedData && (
-          <TrackForm
-            initialData={fetchedData}
-            onSubmit={handleStep2Submit}
-            onBack={handleBack}
-            mode="add"
-            artists={[
-              ...fetchedData.artist.map((artist) => ({
-                value: artist,
-                label: artist,
-              })),
-              ...(data ?? []),
-            ]}
-          />
+          <>
+            <TrackForm
+              initialData={fetchedData}
+              onSubmit={handleStep2Submit}
+              onBack={handleBack}
+              mode="add"
+              artists={[
+                ...fetchedData.artist.map((artist) => ({
+                  value: artist,
+                  label: artist,
+                })),
+                ...(artists ?? []),
+              ]}
+            />
+            <PlaylistSelector
+              options={formattedPlaylists ?? []}
+              selected={selectedPlaylists}
+              onChange={setSelectedPlaylists}
+            />
+            <Button type="submit" form="track-form">
+              Add Song
+            </Button>
+            <Button onClick={handleBack}>Back</Button>
+          </>
         )}
       </SheetContent>
     </Sheet>

--- a/src/app/_components/forms/EditTrack.tsx
+++ b/src/app/_components/forms/EditTrack.tsx
@@ -11,6 +11,7 @@ import { api } from "~/trpc/react";
 import { type AddTrackFormData } from "./TrackForm";
 import type { PlaylistTrack } from "~/app/_components/player/types/player";
 import { useRouter } from "next/navigation";
+import { Button } from "~/components/ui/button";
 
 export const EditTrack = ({
   open,
@@ -74,12 +75,17 @@ export const EditTrack = ({
           <SheetDescription>Edit a song in your library.</SheetDescription>
         </div>
         {initialData && (
-          <TrackForm
-            initialData={initialData}
-            onSubmit={handleSubmit}
-            mode="edit"
-            artists={data ?? []}
-          />
+          <>
+            <TrackForm
+              initialData={initialData}
+              onSubmit={handleSubmit}
+              mode="edit"
+              artists={data ?? []}
+            />
+            <Button type="submit" form="track-form">
+              Submit
+            </Button>
+          </>
         )}
       </SheetContent>
     </Sheet>

--- a/src/app/_components/forms/TrackForm.tsx
+++ b/src/app/_components/forms/TrackForm.tsx
@@ -9,7 +9,6 @@ import { Input } from "~/components/ui/input";
 import { useForm } from "react-hook-form";
 import { MultiSelect } from "./MultiSelectCombo";
 import { type TrackData } from "~/lib/actions/getTrackData";
-import { Button } from "~/components/ui/button";
 import type { SongSource } from "@prisma/client";
 
 export interface AddTrackFormData {
@@ -27,7 +26,6 @@ export interface AddTrackFormData {
 export const TrackForm = ({
   initialData,
   onSubmit,
-  onBack,
   mode,
   artists,
 }: {
@@ -90,7 +88,11 @@ export const TrackForm = ({
         />
       )}
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+        <form
+          onSubmit={form.handleSubmit(handleSubmit)}
+          className="space-y-4"
+          id="track-form"
+        >
           <FormField
             control={form.control}
             name="title"
@@ -134,12 +136,6 @@ export const TrackForm = ({
             )}
           />
           <p>Source: {initialData.source}</p>
-          <Button type="submit">{mode == "add" ? "Add Song" : "Submit"}</Button>
-          {mode == "add" && (
-            <Button type="button" onClick={onBack}>
-              Back
-            </Button>
-          )}
         </form>
       </Form>
     </div>


### PR DESCRIPTION
### TL;DR

Enhanced the track management UI by adding playlist selection during track addition and improving form submission flow.

### What changed?

- Added a `PlaylistSelector` component to the `AddTrack` form, allowing users to add tracks directly to playlists
- Implemented playlist state management with `selectedPlaylists` state
- Added functionality to update playlists when a track is added
- Moved submit buttons out of the `TrackForm` component and into parent components
- Added form ID to the track form for external button submission
- Improved state reset logic when forms are closed
- Added cache invalidation for playlists when tracks are added

### How to test?

1. Open the Add Track form
2. Enter a track URL and proceed to step 2
3. Fill in track details and select one or more playlists
4. Submit the form and verify the track is added to the selected playlists
5. Test the Edit Track form to ensure it works correctly with the new button placement

### Why make this change?

This change improves the user experience by allowing tracks to be added to playlists in a single workflow, rather than requiring separate actions. It also creates a more consistent UI pattern by separating the form fields from the submission controls, making the interface more maintainable and extensible.