### PR TITLE
add spotify credentials to db

### DIFF
--- a/prisma/migrations/20251118000427_add_spotify_credentials/migration.sql
+++ b/prisma/migrations/20251118000427_add_spotify_credentials/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "spotifyAccessToken" TEXT,
+ADD COLUMN     "spotifyRefreshToken" TEXT,
+ADD COLUMN     "spotifyTokenExpiresAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,10 @@ model User {
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 
+    spotifyAccessToken String?
+    spotifyRefreshToken String?
+    spotifyTokenExpiresAt DateTime?
+
     playlists         Playlist[]
     libraryTracks     LibraryTrack[]
 }


### PR DESCRIPTION
### TL;DR

Added Spotify authentication credentials to the User model.

### What changed?

- Added three new columns to the User table:
  - `spotifyAccessToken`: Stores the Spotify API access token
  - `spotifyRefreshToken`: Stores the refresh token for obtaining new access tokens
  - `spotifyTokenExpiresAt`: Tracks when the access token expires

- Created a new migration file to apply these schema changes to the database


### Why make this change?

This change enables Spotify integration by allowing the application to securely store user authentication credentials. With these fields, the app can make authorized API calls to Spotify on behalf of users