### PR TITLE
update context menu and add spotify page

### DIFF
--- a/src/app/_components/ContextMenu.tsx
+++ b/src/app/_components/ContextMenu.tsx
@@ -14,7 +14,11 @@ import { SignOutButton, useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-export const GlobalContextMenu = () => {
+export const GlobalContextMenu = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const router = useRouter();
   const { isSignedIn } = useUser();
   const [addSongOpen, setAddSongOpen] = useState(false);
@@ -23,14 +27,6 @@ export const GlobalContextMenu = () => {
   if (!isSignedIn) {
     return null;
   }
-
-  const handlePlaylists = () => {
-    router.push("/playlists");
-  };
-
-  const handleLibrary = () => {
-    router.push("/library");
-  };
 
   const handleAddSong = () => {
     setAddSongOpen(true);
@@ -43,8 +39,8 @@ export const GlobalContextMenu = () => {
   return (
     <>
       <ContextMenu>
-        <ContextMenuTrigger>
-          <div className="fixed inset-0 -z-10" />
+        <ContextMenuTrigger asChild>
+          <div className="fixed inset-0">{children}</div>
         </ContextMenuTrigger>
         <ContextMenuContent className="z-100">
           <ContextMenuItem onClick={handleAddSong}>add song</ContextMenuItem>
@@ -52,9 +48,16 @@ export const GlobalContextMenu = () => {
             add playlist
           </ContextMenuItem>
           <ContextMenuSeparator />
-          <ContextMenuItem onClick={handlePlaylists}>playlists</ContextMenuItem>
-          <ContextMenuItem onClick={handleLibrary}>library</ContextMenuItem>
+          <ContextMenuItem onClick={() => router.push("/playlists")}>
+            playlists
+          </ContextMenuItem>
+          <ContextMenuItem onClick={() => router.push("/library")}>
+            library
+          </ContextMenuItem>
           <ContextMenuSeparator />
+          <ContextMenuItem onClick={() => router.push("/account")}>
+            account
+          </ContextMenuItem>
           <ContextMenuItem>
             <SignOutButton>log out</SignOutButton>
           </ContextMenuItem>

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,0 +1,12 @@
+import { Button } from "~/components/ui/button";
+
+const Account = () => {
+  return (
+    <main className="flex h-screen flex-col items-center justify-center">
+      <h1>Account</h1>
+      <Button>Connect Spotify</Button>
+    </main>
+  );
+};
+
+export default Account;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,8 +27,7 @@ export default function RootLayout({
       <html lang="en" className={`${geist.variable}`}>
         <body>
           <TRPCReactProvider>
-            {children}
-            <GlobalContextMenu />
+            <GlobalContextMenu>{children}</GlobalContextMenu>
             <MusicPlayer />
           </TRPCReactProvider>
         </body>


### PR DESCRIPTION
### TL;DR

added basic account page with Spotify connection option. also added to the context menu

### What changed?

- Modified `GlobalContextMenu` to accept children as props, allowing it to wrap the entire application
- Restructured the context menu trigger to use `asChild` and properly render children
- Simplified navigation handlers by using inline functions
- Added a new "account" option to the context menu
- Created a new `/account` page with a "Connect Spotify" button
- Updated the root layout to wrap children with the context menu component


### Why make this change?

Account page is needed now for authorizing the spotify account. may extend in the future with other services