### PR TITLE
spotify auth state

### DIFF
--- a/prisma/migrations/20251118160736_add_spotify_auth_table/migration.sql
+++ b/prisma/migrations/20251118160736_add_spotify_auth_table/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "public"."SpotifyAuthState" (
+    "id" SERIAL NOT NULL,
+    "state" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SpotifyAuthState_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SpotifyAuthState_state_key" ON "public"."SpotifyAuthState"("state");
+
+-- CreateIndex
+CREATE INDEX "SpotifyAuthState_state_idx" ON "public"."SpotifyAuthState"("state");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,3 +137,12 @@ model LibraryTrackArtist {
 
     @@id([libraryTrackId, artistId])
 }
+
+model SpotifyAuthState {
+    id        Int      @id @default(autoincrement())
+    state     String   @unique
+    userId    String
+    createdAt DateTime @default(now())
+
+    @@index([state])
+}


### PR DESCRIPTION
### TL;DR

Added a new `SpotifyAuthState` table. Will be used as a temporary store when authorizing a user. in theory gets cleaned up in the following step.

### What changed?

- Created a new Prisma model `SpotifyAuthState` with fields for id, state, userId, and createdAt
- Added a migration file that:
  - Creates the `SpotifyAuthState` table in the public schema
  - Sets up a unique constraint on the `state` field

### Why make this change?

This table is necessary for implementing secure Spotify OAuth authentication. The state parameter is a security measure recommended by OAuth 2.0 to prevent CSRF attacks. By storing the state along with the userId, we can validate authentication callbacks and ensure they match legitimate authentication requests initiated by our users.