### PR TITLE
update linting rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,13 @@ export default tseslint.config(
         "error",
         { checksVoidReturn: { attributes: false } },
       ],
+      // additions, was just becoming noise, ts should cover
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "no-console": ["warn", { allow: ["warn", "error"] }],
     },
   },
   {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "checkJs": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
 
     /* Bundled projects */
     "lib": ["dom", "dom.iterable", "ES2022"],
@@ -27,7 +29,8 @@
     /* Path Aliases */
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./*"]
     }
   },
   "include": [


### PR DESCRIPTION
### TL;DR

Adjusted TypeScript and ESLint configurations to improve developer experience.

### What changed?

- Disabled several TypeScript ESLint rules that were generating noise:
  - `@typescript-eslint/no-unsafe-assignment`
  - `@typescript-eslint/no-unsafe-call`
  - `@typescript-eslint/no-unsafe-member-access`
  - `@typescript-eslint/no-unsafe-return`
- Changed `@typescript-eslint/no-explicit-any` from error to warning
- Added `no-console` warning rule (allowing `console.warn` and `console.error`)
- Enabled TypeScript compiler options:
  - `noUnusedLocals`
  - `noUnusedParameters`
- Added a new path alias `@/*` pointing to the root directory

### How to test?

1. Run ESLint to verify the new configuration works as expected
2. Check that TypeScript compilation still works with the new settings
3. Try using the new `@/*` path alias in imports

### Why make this change?

The TypeScript ESLint rules that were disabled were creating excessive noise in the codebase while TypeScript's type checking should already cover these cases. The additional compiler options help catch unused code, and the new path alias provides more flexibility when importing from the project root.