### PR TITLE
spotify refresh token

### DIFF
--- a/src/app/api/spotify/callback/route.test.ts
+++ b/src/app/api/spotify/callback/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { db } from "@/vitest.setup";
+import { testDb } from "@/vitest.setup";
 
 import { GET } from "./route";
 import { NextRequest } from "next/server";
@@ -34,7 +34,7 @@ describe("spotify callback route", () => {
     expect(location).toContain("/account?error=state_mismatch");
   });
   it("should redirect if there is a state mismatch", async () => {
-    await db.spotifyAuthState.create({
+    await testDb.spotifyAuthState.create({
       data: {
         state: "wrongstate",
         userId: "test-user-id",
@@ -53,7 +53,7 @@ describe("spotify callback route", () => {
   it("should redirect if env variables are not set", async () => {
     vi.stubEnv("SPOTIFY_CLIENT_ID", undefined);
 
-    await db.spotifyAuthState.create({
+    await testDb.spotifyAuthState.create({
       data: {
         state: "teststate",
         userId: "test-user-id",
@@ -69,12 +69,12 @@ describe("spotify callback route", () => {
     const location = response.headers.get("Location");
     expect(location).toContain("/account?error=config_error");
 
-    await expect(db.spotifyAuthState.findFirst()).resolves.toBeNull();
+    await expect(testDb.spotifyAuthState.findFirst()).resolves.toBeNull();
 
     vi.unstubAllEnvs();
   });
   it("should redirect if token exchange fails", async () => {
-    await db.spotifyAuthState.create({
+    await testDb.spotifyAuthState.create({
       data: {
         state: "teststate",
         userId: "test-user-id",
@@ -98,7 +98,7 @@ describe("spotify callback route", () => {
     fetchSpy.mockRestore();
   });
   it("should redirect if invalid token data", async () => {
-    await db.spotifyAuthState.create({
+    await testDb.spotifyAuthState.create({
       data: {
         state: "teststate",
         userId: "test-user-id",
@@ -129,14 +129,14 @@ describe("spotify callback route", () => {
   it("should redirect to account page with success", async () => {
     const fixedDate = new Date("2025-01-01T12:00:00.000Z");
     vi.useFakeTimers({ now: fixedDate });
-    await db.spotifyAuthState.create({
+    await testDb.spotifyAuthState.create({
       data: {
         state: "teststate",
         userId: "test-user-id",
       },
     });
 
-    await db.user.create({
+    await testDb.user.create({
       data: {
         clerkId: "test-user-id",
       },
@@ -161,7 +161,7 @@ describe("spotify callback route", () => {
     const location = response.headers.get("Location");
     expect(location).toContain("/account?success=true");
 
-    const user = await db.user.findUnique({
+    const user = await testDb.user.findUnique({
       where: { clerkId: "test-user-id" },
     });
     expect(user).toBeDefined();
@@ -174,7 +174,7 @@ describe("spotify callback route", () => {
     vi.useRealTimers();
   });
   it("should redirect to account page with error", async () => {
-    await db.spotifyAuthState.create({
+    await testDb.spotifyAuthState.create({
       data: {
         state: "teststate",
         userId: "test-user-id",

--- a/src/app/api/spotify/login/route.test.ts
+++ b/src/app/api/spotify/login/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { db } from "@/vitest.setup";
+import { testDb } from "@/vitest.setup";
 
 import { mockClerkUnauthenticated, mockClerkAuth } from "~/test-utils/mocks";
 import { GET } from "./route";
@@ -23,6 +23,7 @@ describe("spotify login route", () => {
     expect(response.status).toBe(307);
     const location = response.headers.get("Location");
     expect(location).toContain("/account?error=config_error");
+
     vi.unstubAllEnvs();
   });
   it("should redirect to spotify and store state in db", async () => {
@@ -43,7 +44,7 @@ describe("spotify login route", () => {
     const state = params.get("state");
     expect(state).toBeDefined();
 
-    const storedState = await db.spotifyAuthState.findUnique({
+    const storedState = await testDb.spotifyAuthState.findUnique({
       where: { state: state! },
     });
     expect(storedState).toBeDefined();

--- a/src/lib/actions/getOrRefreshSpotifyToken.ts
+++ b/src/lib/actions/getOrRefreshSpotifyToken.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { getOrRefreshSpotifyToken as getOrRefreshSpotifyTokenServer } from "~/server/lib/spotify/getOrRefreshSpotifyToken";
+import { auth } from "@clerk/nextjs/server";
+
+export async function getOrRefreshSpotifyToken(): Promise<string> {
+  const { userId } = await auth();
+
+  if (!userId) {
+    throw new Error("getOrRefreshSpotifyToken called without userId");
+  }
+
+  return await getOrRefreshSpotifyTokenServer({ clerkId: userId });
+}

--- a/src/server/lib/spotify/getOrRefreshSpotifyToken.test.ts
+++ b/src/server/lib/spotify/getOrRefreshSpotifyToken.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { testDb } from "@/vitest.setup";
+import * as refreshSpotifyTokenModule from "./refreshSpotifyToken";
+import { getOrRefreshSpotifyToken } from "./getOrRefreshSpotifyToken";
+
+describe("getOrRefreshSpotifyToken", () => {
+  it("should error if user not found", async () => {
+    await expect(
+      getOrRefreshSpotifyToken({
+        clerkId: "test",
+      }),
+    ).rejects.toThrow("User not found");
+  });
+  it("should error if user has no Spotify token", async () => {
+    await testDb.user.create({
+      data: {
+        clerkId: "test",
+        spotifyAccessToken: "meh",
+        spotifyRefreshToken: "blahblah",
+        spotifyTokenExpiresAt: null,
+      },
+    });
+    await expect(
+      getOrRefreshSpotifyToken({
+        clerkId: "test",
+      }),
+    ).rejects.toThrow("User is missing Spotify credentials, reauthorize");
+  });
+  it("should return the user's existing token if not expired", async () => {
+    await testDb.user.create({
+      data: {
+        clerkId: "test",
+        spotifyAccessToken: "meh",
+        spotifyRefreshToken: "blahblah",
+        spotifyTokenExpiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7), // 1 week from now
+      },
+    });
+
+    const token = await getOrRefreshSpotifyToken({
+      clerkId: "test",
+    });
+    expect(token).toBe("meh");
+  });
+  it("should refresh the token if it is expired", async () => {
+    await testDb.user.create({
+      data: {
+        clerkId: "test",
+        spotifyAccessToken: "meh",
+        spotifyRefreshToken: "blahblah",
+        spotifyTokenExpiresAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7), // 1 week ago
+      },
+    });
+
+    const refreshSpotifyTokenSpy = vi.spyOn(
+      refreshSpotifyTokenModule,
+      "refreshSpotifyToken",
+    );
+    refreshSpotifyTokenSpy.mockResolvedValue("new-token");
+
+    const token = await getOrRefreshSpotifyToken({
+      clerkId: "test",
+    });
+    expect(token).toBe("new-token");
+    expect(refreshSpotifyTokenSpy).toHaveBeenCalledWith({
+      user: expect.objectContaining({
+        clerkId: "test",
+        spotifyAccessToken: "meh",
+        spotifyRefreshToken: "blahblah",
+        spotifyTokenExpiresAt: expect.any(Date),
+      }),
+    });
+
+    refreshSpotifyTokenSpy.mockRestore();
+  });
+});

--- a/src/server/lib/spotify/getOrRefreshSpotifyToken.ts
+++ b/src/server/lib/spotify/getOrRefreshSpotifyToken.ts
@@ -1,0 +1,30 @@
+import { db } from "~/server/db";
+import { refreshSpotifyToken } from "./refreshSpotifyToken";
+
+export const getOrRefreshSpotifyToken = async ({
+  clerkId,
+}: {
+  clerkId: string;
+}): Promise<string> => {
+  const user = await db.user.findUnique({
+    where: { clerkId },
+  });
+
+  if (!user) {
+    throw new Error("User not found");
+  }
+
+  if (
+    !user.spotifyAccessToken ||
+    !user.spotifyTokenExpiresAt ||
+    !user.spotifyRefreshToken
+  ) {
+    throw new Error("User is missing Spotify credentials, reauthorize");
+  }
+
+  if (user.spotifyTokenExpiresAt < new Date()) {
+    return await refreshSpotifyToken({ user });
+  }
+
+  return user.spotifyAccessToken;
+};

--- a/src/server/lib/spotify/refreshSpotifyToken.test.ts
+++ b/src/server/lib/spotify/refreshSpotifyToken.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from "vitest";
+import { testDb } from "@/vitest.setup";
+import { refreshSpotifyToken } from "./refreshSpotifyToken";
+import type { User } from "@prisma/client";
+
+describe("refreshSpotifyToken", () => {
+  it("should error if no credentials", async () => {
+    vi.stubEnv("SPOTIFY_CLIENT_ID", undefined);
+
+    await expect(
+      refreshSpotifyToken({ user: { id: 1 } as User }),
+    ).rejects.toThrow("Spotify client ID or secret not found");
+
+    vi.unstubAllEnvs();
+  });
+  it("should error if user doesn't have a refresh token", async () => {
+    await expect(
+      refreshSpotifyToken({ user: { id: 1 } as User }),
+    ).rejects.toThrow("User has no Spotify refresh token, reauthorize");
+  });
+  it("should error if token refresh fails", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      text: async () => "not good",
+    } as Response);
+
+    await expect(
+      refreshSpotifyToken({
+        user: { id: 1, spotifyRefreshToken: "test" } as User,
+      }),
+    ).rejects.toThrow("Token response not ok: not good");
+
+    fetchSpy.mockRestore();
+  });
+  it("should return the new token and update old refresh token when received", async () => {
+    const user = await testDb.user.create({
+      data: {
+        clerkId: "test",
+        spotifyRefreshToken: "old refresh",
+        spotifyAccessToken: "old access",
+      },
+    });
+
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      text: async () => "all good",
+      json: async () => ({
+        access_token: "new access",
+        refresh_token: "new refresh",
+        expires_in: 3600,
+      }),
+    } as Response);
+
+    const token = await refreshSpotifyToken({ user });
+    expect(token).toBe("new access");
+
+    const updatedUser = await testDb.user.findUnique({
+      where: { id: user.id },
+    });
+    expect(updatedUser?.spotifyAccessToken).toBe("new access");
+    expect(updatedUser?.spotifyRefreshToken).toBe("new refresh");
+    expect(updatedUser?.spotifyTokenExpiresAt).toBeDefined();
+
+    fetchSpy.mockRestore();
+  });
+  it("should return the new token and work if refresh token is not included", async () => {
+    const user = await testDb.user.create({
+      data: {
+        clerkId: "test",
+        spotifyRefreshToken: "old refresh",
+        spotifyAccessToken: "old access",
+      },
+    });
+
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      text: async () => "all good",
+      json: async () => ({
+        access_token: "new access",
+        expires_in: 3600,
+      }),
+    } as Response);
+
+    const token = await refreshSpotifyToken({ user });
+    expect(token).toBe("new access");
+
+    const updatedUser = await testDb.user.findUnique({
+      where: { id: user.id },
+    });
+    expect(updatedUser?.spotifyAccessToken).toBe("new access");
+    expect(updatedUser?.spotifyRefreshToken).toBe("old refresh");
+    expect(updatedUser?.spotifyTokenExpiresAt).toBeDefined();
+
+    fetchSpy.mockRestore();
+  });
+  it("should error if something goes wrong in try block", async () => {
+    const user = await testDb.user.create({
+      data: {
+        clerkId: "test",
+        spotifyRefreshToken: "old refresh",
+        spotifyAccessToken: "old access",
+      },
+    });
+
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockRejectedValue(new Error("Network error"));
+
+    await expect(refreshSpotifyToken({ user })).rejects.toThrow(
+      "Failed to refresh Spotify token: Network error",
+    );
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/server/lib/spotify/refreshSpotifyToken.ts
+++ b/src/server/lib/spotify/refreshSpotifyToken.ts
@@ -1,0 +1,68 @@
+// https://developer.spotify.com/documentation/web-api/tutorials/refreshing-tokens
+import type { User } from "@prisma/client";
+import { db } from "~/server/db";
+
+export const refreshSpotifyToken = async ({
+  user,
+}: {
+  user: User;
+}): Promise<string> => {
+  const clientId = process.env.SPOTIFY_CLIENT_ID;
+  const clientSecret = process.env.SPOTIFY_SECRET_KEY;
+
+  if (!clientId || !clientSecret) {
+    throw new Error("Spotify client ID or secret not found");
+  }
+
+  // don't plan to call this on it's own, only through checkAndRefreshSpotifyToken.
+  // But have this guard here in case it happens accidentally
+  if (!user.spotifyRefreshToken) {
+    throw new Error("User has no Spotify refresh token, reauthorize");
+  }
+
+  try {
+    const tokenResponse = await fetch(
+      "https://accounts.spotify.com/api/token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Authorization:
+            "Basic " +
+            Buffer.from(`${clientId}:${clientSecret}`).toString("base64"),
+        },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: user.spotifyRefreshToken,
+        }),
+      },
+    );
+
+    if (!tokenResponse.ok) {
+      throw new Error("Token response not ok: " + (await tokenResponse.text()));
+    }
+
+    const tokenData = await tokenResponse.json();
+
+    await db.user.update({
+      where: { id: user.id },
+      data: {
+        spotifyAccessToken: tokenData.access_token,
+        spotifyTokenExpiresAt: new Date(
+          Date.now() + tokenData.expires_in * 1000,
+        ),
+        // usually not included but they can be rotated
+        ...(tokenData.refresh_token
+          ? { spotifyRefreshToken: tokenData.refresh_token }
+          : {}),
+      },
+    });
+
+    return tokenData.access_token;
+  } catch (error) {
+    console.error("Error refreshing Spotify token:", error);
+    throw new Error(
+      "Failed to refresh Spotify token: " + (error as Error).message,
+    );
+  }
+};

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -40,4 +40,4 @@ beforeEach(async () => {
   } as unknown as never);
 });
 
-export { testDb as db };
+export { testDb };


### PR DESCRIPTION
### TL;DR

Added Spotify token refresh functionality with proper error handling and testing.

### What changed?

- Renamed `db` to `testDb` in test files for clarity
- Created a new server action `getOrRefreshSpotifyToken` that authenticates the user and calls the server-side implementation
- Implemented server-side `getOrRefreshSpotifyToken` that checks if a token is expired and refreshes it if needed
- Added `refreshSpotifyToken` function that handles the Spotify API token refresh flow
- Added comprehensive tests for all new functionality with various edge cases

### How to test?

1. Connect a Spotify account to the application
2. Wait for the token to expire (or manually set the expiration date in the database)
3. Attempt to use a Spotify API feature - the token should refresh automatically
4. Check the database to verify the token was updated with a new expiration date

### Why make this change?

Spotify access tokens expire after a short period, but refresh tokens can be used to obtain new access tokens without requiring the user to re-authenticate. This implementation ensures users maintain uninterrupted access to Spotify features by automatically refreshing expired tokens in the background.