### PR TITLE
fix vitest global setup

### DIFF
--- a/vitest.global-setup.ts
+++ b/vitest.global-setup.ts
@@ -1,6 +1,17 @@
 import { execSync } from "node:child_process";
+import dotenv from "dotenv";
 
 export default async function globalSetup() {
+  // seems like for global setup files, vitest doesn't load env
+  // but works fine for normal setup files
+  dotenv.config({ path: ".env" });
+
+  if (!process.env.TEST_DATABASE_URL) {
+    throw new Error(
+      "TEST_DATABASE_URL environment variable is not set. Please set it in your .env file.",
+    );
+  }
+
   execSync("npx prisma migrate reset --force", {
     env: { ...process.env, DATABASE_URL: process.env.TEST_DATABASE_URL },
     stdio: "ignore",


### PR DESCRIPTION
### TL;DR

Added environment validation for test database configuration in the Vitest global setup.

### What changed?

- Added dotenv configuration to explicitly load environment variables in the global setup file
- Added validation to check if `TEST_DATABASE_URL` is defined
- Throws a clear error message when the required environment variable is missing

### How to test?

1. Ensure your `.env` file has a valid `TEST_DATABASE_URL` configured
2. Run the test suite to verify the setup works correctly
3. Temporarily remove the `TEST_DATABASE_URL` from your `.env` file to confirm the error is thrown

### Why make this change?

Vitest doesn't automatically load environment variables in global setup files (unlike normal setup files). This change ensures that the required test database configuration is properly loaded and validated before attempting database migrations, preventing confusing errors that might occur when the database URL is missing.