### PR TITLE
fetch spotify track data

### DIFF
--- a/src/lib/actions/getTrackData.ts
+++ b/src/lib/actions/getTrackData.ts
@@ -4,7 +4,14 @@ import {
   getTrackData as getTrackDataServer,
   type TrackData,
 } from "~/server/lib/getTrackData";
+import { auth } from "@clerk/nextjs/server";
 
-export async function getTrackData(url: string): Promise<TrackData> {
-  return await getTrackDataServer(url);
-}
+export const getTrackData = async (url: string): Promise<TrackData> => {
+  const { userId } = await auth();
+
+  if (!userId) {
+    throw new Error("getTrackData called without userId");
+  }
+
+  return await getTrackDataServer({ url, clerkId: userId });
+};

--- a/src/server/lib/getTrackData.ts
+++ b/src/server/lib/getTrackData.ts
@@ -1,6 +1,7 @@
 import { type SongSource } from "@prisma/client";
 import { fetchSoundCloudTrackData } from "./soundcloud/fetchSoundCloudTrackData";
 import { fetchYouTubeTrackData } from "./youtube/fetchYouTubeTrackData";
+import { fetchSpotifyTrackData } from "./spotify/fetchSpotifyTrackData";
 
 export interface TrackData {
   id?: number;
@@ -14,17 +15,28 @@ export interface TrackData {
   source: SongSource;
 }
 
-export async function getTrackData(url: string): Promise<TrackData> {
-  const source = url.includes("soundcloud") ? "soundcloud" : "youtube";
+export async function getTrackData({
+  url,
+  clerkId,
+}: {
+  url: string;
+  clerkId: string;
+}): Promise<TrackData> {
+  const sources: SongSource[] = ["soundcloud", "youtube", "spotify"];
+  const source = sources.find((s) => url.includes(s)) ?? null;
 
-  try {
-    if (source === "soundcloud") {
+  if (!source) {
+    throw new Error("Invalid source");
+  }
+
+  switch (source) {
+    case "soundcloud":
       return await fetchSoundCloudTrackData(url);
-    } else {
+    case "youtube":
       return await fetchYouTubeTrackData(url);
-    }
-  } catch (error) {
-    console.error(error);
-    throw new Error("Failed to get track data");
+    case "spotify":
+      return await fetchSpotifyTrackData({ url, clerkId });
+    default:
+      throw new Error("Invalid source");
   }
 }

--- a/src/server/lib/soundcloud/fetchSoundCloudTrackData.ts
+++ b/src/server/lib/soundcloud/fetchSoundCloudTrackData.ts
@@ -1,6 +1,6 @@
 import { type TrackData } from "~/server/lib/getTrackData";
 
-interface SoundCloudResolveResponse {
+interface SoundCloudResponse {
   title: string;
   duration: number;
   artwork_url: string;
@@ -58,7 +58,7 @@ export async function fetchSoundCloudTrackData(
     );
   }
 
-  const data = (await res.json()) as SoundCloudResolveResponse;
+  const data = (await res.json()) as SoundCloudResponse;
 
   return {
     title: data.title,

--- a/src/server/lib/spotify/fetchSpotifyTrackData.ts
+++ b/src/server/lib/spotify/fetchSpotifyTrackData.ts
@@ -1,0 +1,86 @@
+// https://developer.spotify.com/documentation/web-api/reference/get-track
+import { type TrackData } from "~/server/lib/getTrackData";
+import { getOrRefreshSpotifyToken } from "~/server/lib/spotify/getOrRefreshSpotifyToken";
+
+interface SpotifyResponse {
+  album: {
+    album_type: "album" | "single" | "compilation";
+    total_tracks: number;
+    external_urls: {
+      spotify: string;
+    };
+    name: string;
+    images: {
+      // various sizes of cover art, largest is the first in the array
+      url: string;
+      height: number;
+      width: number;
+    }[];
+  };
+  artists: {
+    external_urls: {
+      spotify: string;
+    };
+    href: string;
+    id: string;
+    name: string;
+  }[];
+  duration_ms: number;
+  external_urls: {
+    spotify: string;
+  };
+  href: string;
+  id: string;
+  is_playable: boolean;
+  name: string;
+}
+
+// TODO: brittle :), find more cases where it may break
+const getSpotifyId = (url: string) => {
+  const u = new URL(url);
+  const [, type, id] = u.pathname.split("/");
+  if (type !== "track") return null;
+  return id ?? null;
+};
+
+// TODO: testing
+export const fetchSpotifyTrackData = async ({
+  url,
+  clerkId,
+}: {
+  url: string;
+  clerkId: string;
+}): Promise<TrackData> => {
+  const token = await getOrRefreshSpotifyToken({ clerkId });
+  const spotifyId = getSpotifyId(url);
+
+  if (!spotifyId) {
+    throw new Error("Invalid Spotify ID");
+  }
+
+  const spotifyUrl = `https://api.spotify.com/v1/tracks/${spotifyId}`;
+  const response = await fetch(spotifyUrl, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("Spotify API error:", errorText);
+    throw new Error(`Spotify API error: ${errorText}`);
+  }
+
+  const data = (await response.json()) as SpotifyResponse;
+
+  return {
+    title: data.name,
+    artist: data.artists.map((artist) => artist.name),
+    album: "",
+    duration: data.duration_ms,
+    artworkUrl: data.album.images[0]?.url ?? "",
+    sourceUrl: url,
+    sourceId: data.id,
+    source: "spotify" as const,
+  };
+};

--- a/src/server/lib/youtube/fetchYouTubeTrackData.ts
+++ b/src/server/lib/youtube/fetchYouTubeTrackData.ts
@@ -25,10 +25,12 @@ interface YoutubeResponse {
   }[];
 }
 
+// TODO: brittle :)
 const getYoutubeId = (url: string) => {
   const parsed = new URL(url);
   return parsed.searchParams.get("v");
 };
+
 // TODO: make this still function without auth and test it
 export async function fetchYouTubeTrackData(url: string): Promise<TrackData> {
   const youtubeId = getYoutubeId(url);


### PR DESCRIPTION
### TL;DR

Added Spotify track support to the music platform alongside existing YouTube and SoundCloud integrations.

### What changed?

- Added a new `fetchSpotifyTrackData` function to retrieve track information from Spotify's API
- Updated `getTrackData` to support Spotify as a source alongside YouTube and SoundCloud
- Modified the client-side `getTrackData` action to include user authentication via Clerk
- Refactored the server-side `getTrackData` function to accept an object with URL and clerk ID
- Improved source detection logic to handle multiple music platforms
- Enhanced error handling for invalid sources

### How to test?

1. Ensure you're logged in with a Clerk account
2. Try adding a Spotify track URL to verify it retrieves track data correctly
3. Confirm existing YouTube and SoundCloud functionality still works
4. Test error handling by providing invalid URLs

### Why make this change?

This change expands the platform's music source capabilities by adding Spotify integration, giving users more options for adding music from different platforms. The authentication improvements ensure proper user context when fetching track data, particularly important for the Spotify API which requires authentication.