### PR TITLE
spotify adapter and integration

### DIFF
--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -1,5 +1,6 @@
 import { SoundCloudAdapter } from "./adapters/SoundCloudAdapter";
 import { YouTubeAdapter } from "./adapters/YouTubeAdapter";
+import { SpotifyAdapter } from "./adapters/SpotifyAdapter";
 import type {
   MusicPlayerAdapter,
   PlaylistTrack,
@@ -29,6 +30,9 @@ export class AudioController {
         break;
       case "youtube":
         adapter = new YouTubeAdapter();
+        break;
+      case "spotify":
+        adapter = new SpotifyAdapter();
         break;
       default:
         console.error(`Unsupported track source: ${source}`);
@@ -62,6 +66,8 @@ export class AudioController {
         return track.sourceUrl;
       case "youtube":
         return track.sourceId;
+      case "spotify":
+        return track.sourceId;
       default:
         console.error(`Unsupported track source: ${track.source}`);
         return "";
@@ -82,7 +88,7 @@ export class AudioController {
 
     // if check, only to filter the noise on first play
     if (this.currentAdapter) {
-      this.currentAdapter.pause();
+      await this.currentAdapter.pause();
     }
 
     await this.createAdapterForSource(track.source);
@@ -117,7 +123,7 @@ export class AudioController {
       console.warn("no adapter, play");
       return;
     }
-    this.currentAdapter.play();
+    await this.currentAdapter.play();
   }
 
   async pause() {
@@ -125,7 +131,7 @@ export class AudioController {
       console.warn("no adapter, pause");
       return;
     }
-    this.currentAdapter.pause();
+    await this.currentAdapter.pause();
   }
 
   async isPlaying() {
@@ -136,6 +142,7 @@ export class AudioController {
     return await this.currentAdapter.isPlaying();
   }
 
+  // time related values at this level are in seconds
   async getCurrentTime() {
     if (!this.currentAdapter) {
       console.warn("no adapter, getCurrentTime");
@@ -144,20 +151,21 @@ export class AudioController {
     return await this.currentAdapter.getCurrentTime();
   }
 
-  seekTo(seconds: number) {
+  async seekTo(seconds: number) {
     if (!this.currentAdapter) {
       console.warn("no adapter, seekTo");
       return;
     }
-    this.currentAdapter.seekTo(seconds);
+    await this.currentAdapter.seekTo(seconds);
   }
 
-  setVolume(value: number) {
+  // value is between 0 - 100, adapters are responsible for converting to their own range
+  async setVolume(value: number) {
     if (!this.currentAdapter) {
       console.warn("no adapter, setVolume");
       return;
     }
-    this.currentAdapter.setVolume(value);
+    await this.currentAdapter.setVolume(value);
   }
 
   // GETTERS

--- a/src/app/_components/player/adapters/SpotifyAdapter.ts
+++ b/src/app/_components/player/adapters/SpotifyAdapter.ts
@@ -1,0 +1,226 @@
+// https://developer.spotify.com/documentation/web-playback-sdk/reference#spotifyplayer
+
+import { getOrRefreshSpotifyToken } from "~/lib/actions/getOrRefreshSpotifyToken";
+import type { MusicPlayerAdapter } from "../types/player";
+
+declare global {
+  interface Window {
+    onSpotifyWebPlaybackSDKReady: () => void;
+    Spotify: {
+      Player: new (options: {
+        name: string;
+        getOAuthToken: (cb: (token: string) => void) => void | Promise<void>;
+        volume?: number;
+      }) => SpotifyWidget;
+    };
+  }
+}
+
+interface SpotifyWidget {
+  connect: () => void; // actually returns a promise but the events handle it
+  disconnect: () => void;
+  getCurrentState: () => Promise<SpotifyPlayerState>;
+  setName: (name: string) => Promise<void>;
+  getVolume: () => Promise<number>; // float 0-1
+  setVolume: (volume: number) => Promise<void>;
+  pause: () => Promise<void>;
+  resume: () => Promise<void>;
+  togglePlay: () => Promise<void>;
+  seek: (position: number) => Promise<void>; // position in milliseconds
+  addListener: (
+    event:
+      | "ready"
+      | "not_ready"
+      | "player_state_changed"
+      | "autoplay_failed"
+      | "initialization_error"
+      | "authentication_error"
+      | "account_error"
+      | "playback_error",
+    callback: (data: {
+      device_id: string;
+      message: string;
+    }) => Promise<void> | void,
+  ) => void;
+  removeListener: (eventname: string) => void;
+  on: (event: string, callback: (data: { message: string }) => void) => void;
+}
+
+interface SpotifyPlayerState {
+  // https://developer.spotify.com/documentation/web-playback-sdk/reference#webplaybackstate-object
+  paused: boolean;
+  position: number; // in ms
+}
+
+export class SpotifyAdapter implements MusicPlayerAdapter {
+  private player: SpotifyWidget | null = null;
+  private isReady: boolean = false;
+  private isInitialized: boolean = false;
+  private deviceId: string | null = null;
+
+  private async initializeWidget(trackId: string): Promise<void> {
+    return new Promise((resolve) => {
+      const setupPlayer = () => {
+        const player = new window.Spotify.Player({
+          name: "Aggregate",
+          getOAuthToken: async (cb) => {
+            const token = await getOrRefreshSpotifyToken();
+            cb(token);
+          },
+          volume: 1,
+        });
+
+        this.player = player;
+
+        player.addListener("ready", async ({ device_id }) => {
+          this.deviceId = device_id;
+          this.isInitialized = true;
+          this.isReady = true;
+          await this.loadNewTrack(trackId);
+          resolve();
+        });
+
+        player.addListener("not_ready", ({ device_id }) => {
+          console.warn("Spotify not ready", device_id);
+        });
+
+        player.on("initialization_error", ({ message }) => {
+          console.error("Spotify failed to initialize", message);
+        });
+
+        player.on("authentication_error", ({ message }) => {
+          console.error("Spotify failed to authenticate", message);
+        });
+
+        player.on("playback_error", ({ message }) => {
+          console.error("Spotify failed to connect", message);
+        });
+
+        player.connect();
+      };
+
+      if (window.Spotify) {
+        setupPlayer();
+      } else {
+        window.onSpotifyWebPlaybackSDKReady = setupPlayer;
+      }
+    });
+  }
+
+  async loadTrack(trackId: string): Promise<void> {
+    this.isReady = false;
+
+    if (!this.isInitialized) {
+      await this.initializeWidget(trackId);
+    } else {
+      await this.loadNewTrack(trackId);
+    }
+  }
+
+  private async loadNewTrack(trackId: string): Promise<void> {
+    if (!this.player || !this.isReady) {
+      console.warn("Spotify player not ready for loadNewTrack");
+      return;
+    }
+
+    if (this.deviceId === null) {
+      console.warn("Spotify deviceId not found for loadNewTrack");
+      return;
+    }
+
+    const token = await getOrRefreshSpotifyToken();
+    if (!token) {
+      console.warn("Spotify token not found for loadNewTrack");
+      return;
+    }
+
+    const uri = `spotify:track:${trackId}`;
+
+    const response = await fetch(
+      `https://api.spotify.com/v1/me/player/play?device_id=${this.deviceId}`,
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          uris: [uri],
+          position_ms: 0,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      console.error("Failed to load Spotify track");
+    }
+  }
+
+  async play(): Promise<void> {
+    if (!this.player || !this.isReady) {
+      console.warn("Spotify player not ready for play");
+      return;
+    }
+
+    await this.player.resume();
+  }
+
+  async pause(): Promise<void> {
+    if (!this.player || !this.isReady) {
+      console.warn("Spotify player not ready for pause");
+      return;
+    }
+
+    await this.player.pause();
+  }
+
+  async isPlaying(): Promise<boolean> {
+    if (!this.player || !this.isReady) {
+      console.warn("Spotify player not ready for isPlaying");
+      return false;
+    }
+
+    const state = await this.player.getCurrentState();
+    return !state.paused;
+  }
+
+  async getCurrentTime(): Promise<number> {
+    if (!this.player || !this.isReady) {
+      console.warn("Spotify player not ready for getCurrentTime");
+      return 0;
+    }
+
+    const state = await this.player.getCurrentState();
+    return state.position / 1000;
+  }
+
+  async seekTo(seconds: number): Promise<void> {
+    if (!this.player || !this.isReady) {
+      console.warn("Spotify player not ready for seekTo");
+      return;
+    }
+
+    await this.player.seek(seconds * 1000);
+  }
+
+  async setVolume(value: number): Promise<void> {
+    if (!this.player || !this.isReady) {
+      console.warn("Spotify player not ready for setVolume");
+      return;
+    }
+
+    await this.player.setVolume(value / 100);
+  }
+
+  get duration(): number {
+    if (!this.player || !this.isReady) {
+      console.warn("Spotify player not ready for getDuration");
+      return 0;
+    }
+    // TODO: do the duration from track data
+    // spotify doesn't make it available here and not worth a call
+    return 0;
+  }
+
+  readonly sound: null = null;
+}

--- a/src/app/_components/player/types/player.ts
+++ b/src/app/_components/player/types/player.ts
@@ -2,12 +2,12 @@ import type { SongSource } from "@prisma/client";
 
 export interface MusicPlayerAdapter {
   loadTrack(trackUrl: string): Promise<void>;
-  play(): void;
-  pause(): void;
+  play(): void | Promise<void>;
+  pause(): void | Promise<void>;
   isPlaying(): Promise<boolean>;
   getCurrentTime(): Promise<number>;
-  seekTo(seconds: number): void;
-  setVolume(value: number): void;
+  seekTo(seconds: number): void | Promise<void>;
+  setVolume(value: number): void | Promise<void>;
   readonly duration: number;
   readonly sound: SoundCloudSound | null;
 }

--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -47,9 +47,18 @@ export function useMusicPlayer() {
     };
     document.head.appendChild(ytScript);
 
+    const spotifyScript = document.createElement("script");
+    spotifyScript.src = "https://sdk.scdn.co/spotify-player.js";
+    spotifyScript.async = true;
+    spotifyScript.onload = () => {
+      console.log("Spotify API loaded");
+    };
+    document.body.appendChild(spotifyScript);
+
     return () => {
       document.head.removeChild(scScript);
       document.head.removeChild(ytScript);
+      document.body.removeChild(spotifyScript);
     };
   }, []);
 
@@ -124,7 +133,7 @@ export function useMusicPlayer() {
         setController(newController);
         setIsLoaded(true);
         await newController.play();
-        newController.setVolume(volume);
+        await newController.setVolume(volume);
         setDuration(newController.duration);
         setIsPlaying(true);
       } catch (error) {
@@ -138,7 +147,7 @@ export function useMusicPlayer() {
           setCurrentTime(0);
           setDuration(controller.duration);
           await controller.play();
-          controller.setVolume(volume);
+          await controller.setVolume(volume);
         } catch (error) {
           console.error("Failed to load new track:", error);
         }
@@ -175,7 +184,7 @@ export function useMusicPlayer() {
       setDuration(0.9);
 
       await controller.nextTrack();
-      controller.setVolume(volume);
+      await controller.setVolume(volume);
       setDuration(controller.duration);
       setIsPlaying(true);
     }
@@ -196,7 +205,7 @@ export function useMusicPlayer() {
       // user expectation, if into the song, hitting previous should go back to the start
       // if at the start, go previous track
       if (currentTime > 3) {
-        controller.seekTo(0);
+        await controller.seekTo(0);
         setCurrentTime(0);
         return;
       }
@@ -207,7 +216,7 @@ export function useMusicPlayer() {
       setDuration(0.9);
 
       await controller.previousTrack();
-      controller.setVolume(volume);
+      await controller.setVolume(volume);
       setDuration(controller.duration);
       setIsPlaying(true);
     }
@@ -225,12 +234,12 @@ export function useMusicPlayer() {
   ]);
 
   const handleVolumeChange = useCallback(
-    (volume: number[]) => {
+    async (volume: number[]) => {
       if (volume[0] !== undefined) {
         setVolume(volume[0]);
 
         if (controller && isLoaded) {
-          controller.setVolume(volume[0]);
+          await controller.setVolume(volume[0]);
         }
       }
     },
@@ -248,9 +257,9 @@ export function useMusicPlayer() {
   );
 
   const handleProgressCommit = useCallback(
-    (value: number[]) => {
+    async (value: number[]) => {
       if (controller && isLoaded && value[0] !== undefined) {
-        controller.seekTo(value[0] * 1000);
+        await controller.seekTo(value[0] * 1000);
         setIsSeeking(false);
       }
     },


### PR DESCRIPTION
### TL;DR

Added Spotify integration to the music player, allowing playback of Spotify tracks alongside existing YouTube and SoundCloud support.

### What changed?

- Created a new `SpotifyAdapter` class that implements the `MusicPlayerAdapter` interface
- Added Spotify SDK script loading in the `useMusicPlayer` hook
- Updated the `AudioController` to support Spotify as a track source
- Modified adapter methods to be async-compatible across all adapters
- Added proper volume scaling for Spotify (0-100 to 0-1)
- Added time unit conversion for Spotify (milliseconds to seconds)
- Updated player interface to handle Promise returns from adapter methods

### How to test?

1. Ensure you have a valid Spotify account and token
2. Add a Spotify track to your playlist
3. Play the track and verify basic playback controls work:
   - Play/pause functionality
   - Volume control
   - Seeking within the track
   - Track navigation (next/previous)
4. Verify seamless switching between different track sources (YouTube, SoundCloud, Spotify)

### Why make this change?

Spotify integration expands the music player's capabilities, allowing users to access a wider range of content from one of the most popular streaming platforms. This creates a more comprehensive music experience where users can build playlists that include tracks from multiple sources without needing to switch between different applications.