### PR TITLE
update spotify duration issue

### DIFF
--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -194,6 +194,12 @@ export class AudioController {
       console.warn("no adapter, getDuration");
       return 0;
     }
+
+    const trackDuration = this.currentTrack?.duration;
+    if (trackDuration !== null && trackDuration !== undefined) {
+      return trackDuration / 1000;
+    }
+
     return this.currentAdapter.duration;
   }
 

--- a/src/app/_components/player/adapters/SpotifyAdapter.ts
+++ b/src/app/_components/player/adapters/SpotifyAdapter.ts
@@ -194,13 +194,13 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
     return state.position / 1000;
   }
 
-  async seekTo(seconds: number): Promise<void> {
+  async seekTo(milliseconds: number): Promise<void> {
     if (!this.player || !this.isReady) {
       console.warn("Spotify player not ready for seekTo");
       return;
     }
 
-    await this.player.seek(seconds * 1000);
+    await this.player.seek(milliseconds);
   }
 
   async setVolume(value: number): Promise<void> {
@@ -217,7 +217,6 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
       console.warn("Spotify player not ready for getDuration");
       return 0;
     }
-    // TODO: do the duration from track data
     // spotify doesn't make it available here and not worth a call
     return 0;
   }


### PR DESCRIPTION
### TL;DR

Fixed track duration display for Spotify tracks and corrected the seekTo function parameter in SpotifyAdapter.

### What changed?

- Added fallback to use `currentTrack.duration` in `AudioController.getDuration()` when available
- Modified `SpotifyAdapter.seekTo()` to accept milliseconds directly instead of seconds, removing the conversion
- Removed a TODO comment in `SpotifyAdapter.getDuration()` as we're now handling duration from track data in the controller

### How to test?

1. Play a Spotify track and verify the duration displays correctly
2. Test seeking functionality with Spotify tracks to ensure it works properly
3. Verify that track progress and duration indicators work as expected

### Why make this change?

The Spotify adapter wasn't properly handling track duration, causing the player to display incorrect or missing duration information. Additionally, there was an inconsistency in the `seekTo` function where the parameter was documented as seconds but Spotify's API expects milliseconds. These changes improve the accuracy of track duration display and seeking functionality for Spotify tracks.