### PR TITLE
fix two songs able to play at once

### DIFF
--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -143,6 +143,8 @@ export function useMusicPlayer() {
       const controllerCurrentIndex = controller.getCurrentIndex();
       if (controllerCurrentIndex !== currentTrackIndex) {
         try {
+          await controller.pause();
+          setIsPlaying(false);
           await controller.loadPlaylist(currentPlaylist, currentTrackIndex);
           setCurrentTime(0);
           setDuration(controller.duration);


### PR DESCRIPTION
### TL;DR

Fixed playlist synchronization by pausing playback before loading a new playlist.

### What changed?

Added two lines of code in the `useMusicPlayer` hook to pause the current track and update the playing state before loading a new playlist when the controller's current index doesn't match the expected track index.

### Why make this change?

This fixes a bug where tracks would continue playing while a new playlist was being loaded, causing audio overlap or playback issues. By explicitly pausing the current track before loading a new playlist, we ensure a clean transition between tracks and maintain the correct playing state.