### PR TITLE
added source option for tracks

### DIFF
--- a/src/app/_components/TrackOptions.tsx
+++ b/src/app/_components/TrackOptions.tsx
@@ -73,6 +73,18 @@ export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
         <PopoverContent>
           <div onClick={() => setOpen(true)}>Edit</div>
           <Separator />
+          {song.sourceUrl && (
+            <>
+              <a
+                href={song.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Go to source
+              </a>
+              <Separator />
+            </>
+          )}
           <PlaylistSelector
             options={formattedPlaylists ?? []}
             selected={selectedPlaylists}


### PR DESCRIPTION
### TL;DR

Added a "Go to source" link in the track options menu that opens the original source URL in a new tab.

### What changed?

Added a new option in the track options popover menu that displays a "Go to source" link when a song has a `sourceUrl` property. The link opens the source URL in a new tab with proper security attributes (`target="_blank"` and `rel="noopener noreferrer"`).

### Why make this change?

This enhancement improves user experience by providing direct access to the original source of a track. Users can now easily navigate to where the track was originally found, which is helpful for attribution, finding more information, or exploring related content.