### PR TITLE
library track to be like playlist track

### DIFF
--- a/src/app/library/DataTable.tsx
+++ b/src/app/library/DataTable.tsx
@@ -27,6 +27,11 @@ export type LibraryTrack = {
   sourceId: string | null;
   sourceUrl: string | null;
   artworkUrl: string | null;
+  trackId: number;
+  playlistId: number;
+  playlistName: string;
+  position: number;
+  albumId: number | null;
 };
 
 const columns: ColumnDef<LibraryTrack>[] = [

--- a/src/server/api/routers/library.ts
+++ b/src/server/api/routers/library.ts
@@ -26,8 +26,8 @@ export const libraryRouter = createTRPCRouter({
         title: track.title,
         artists: track.artists.map((artist) => {
           return {
-            id: artist.artistId,
-            name: artist.artist.name,
+            artistId: artist.artistId,
+            artistName: artist.artist.name,
           };
         }),
         album: track.album,
@@ -36,6 +36,13 @@ export const libraryRouter = createTRPCRouter({
         sourceId: track.track.sourceId,
         sourceUrl: track.track.sourceUrl,
         artworkUrl: track.track.artworkUrl,
+
+        // additional fields to satisfy playlistTrack type
+        trackId: track.id,
+        playlistId: -1,
+        playlistName: "",
+        position: 1,
+        albumId: track.album?.id ?? null,
       };
     });
 


### PR DESCRIPTION
### TL;DR

Added additional fields to the LibraryTrack type to align with playlist track requirements.

### What changed?

- Extended the `LibraryTrack` type in `DataTable.tsx` with additional fields: `trackId`, `playlistId`, `playlistName`, `position`, and `albumId`
- Updated the artist object structure in `library.ts` to use `artistId` and `artistName` properties instead of `id` and `name`
- Added placeholder values for the new fields when mapping track data in the library router

### Why make this change?

This change standardizes the track object structure between library tracks and playlist tracks, making it easier to handle both types consistently throughout the application. The additional fields allow library tracks to satisfy the requirements of the playlist track type, enabling better code reuse and simplifying component implementation.