### PR TITLE
music player styling

### DIFF
--- a/src/app/_components/player/components/desktop/MusicPlayer.tsx
+++ b/src/app/_components/player/components/desktop/MusicPlayer.tsx
@@ -23,7 +23,7 @@ export const MusicPlayer = () => {
   if (!loadedOnce) return null;
 
   return (
-    <div className="fixed bottom-10 left-1/2 z-100 flex -translate-x-1/2 gap-4">
+    <div className="bg-background/40 fixed bottom-10 left-1/2 z-100 flex -translate-x-1/2 gap-4 rounded-full p-3 backdrop-blur-[2px]">
       <PlaybackControl
         isPlaying={isPlaying}
         onPlay={play}

--- a/src/app/_components/player/components/desktop/PlaybackControl.tsx
+++ b/src/app/_components/player/components/desktop/PlaybackControl.tsx
@@ -18,29 +18,24 @@ export const PlaybackControl = ({
 }: PlaybackControlProps) => {
   return (
     <div className="flex flex-row gap-2">
-      <Button
-        onClick={onPrevious}
-        className="px-4 py-2 text-white disabled:bg-gray-300"
-      >
-        <SkipBack className="h-4 w-4" />
+      <Button onClick={onPrevious} variant="ghost">
+        <SkipBack className="h-4 w-4" fill="#fff" />
       </Button>
 
       <Button
         onClick={isPlaying ? onPause : onPlay}
-        className="bg-green-500 disabled:bg-gray-300"
+        variant="ghost"
+        size="icon"
       >
         {isPlaying ? (
-          <Pause className="h-4 w-4" />
+          <Pause className="size-6" fill="#fff" />
         ) : (
-          <Play className="h-4 w-4" />
+          <Play fill="#fff" className="size-6" />
         )}
       </Button>
 
-      <Button
-        onClick={onNext}
-        className="px-4 py-2 text-white disabled:bg-gray-300"
-      >
-        <SkipForward className="h-4 w-4" />
+      <Button onClick={onNext} variant="ghost">
+        <SkipForward className="h-4 w-4" fill="#fff" />
       </Button>
     </div>
   );

--- a/src/app/_components/player/components/desktop/ProgressBar.tsx
+++ b/src/app/_components/player/components/desktop/ProgressBar.tsx
@@ -15,7 +15,7 @@ export const ProgressBar = ({
   onProgressCommit,
 }: ProgressBarProps) => {
   return (
-    <>
+    <div className="flex flex-row items-center gap-4">
       <Slider
         value={[currentTime]}
         onValueChange={onProgressChange}
@@ -23,11 +23,12 @@ export const ProgressBar = ({
         max={duration}
         step={1}
         className="w-100"
+        thumbClassName="hidden"
       />
 
       <span className="w-24">
         {formatSongTime(currentTime)} / {formatSongTime(duration)}
       </span>
-    </>
+    </div>
   );
 };

--- a/src/app/_components/player/components/desktop/VolumeControl.tsx
+++ b/src/app/_components/player/components/desktop/VolumeControl.tsx
@@ -19,11 +19,11 @@ export const VolumeControl = ({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="ghost" size="sm">
-          <Volume2 className="h-4 w-4" />
+        <Button variant="ghost" size="icon" className="-ml-1">
+          <Volume2 className="size-4.5" fill="#fff" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent side="top" className="w-fit">
+      <PopoverContent side="top" className="z-101 w-fit">
         <Slider
           value={[volume]}
           onValueChange={onVolumeChange}
@@ -31,6 +31,7 @@ export const VolumeControl = ({
           step={1}
           orientation="vertical"
           className="w-fit"
+          thumbClassName="hidden"
         />
       </PopoverContent>
     </Popover>

--- a/src/app/_components/player/components/mobile/PlayerCard.tsx
+++ b/src/app/_components/player/components/mobile/PlayerCard.tsx
@@ -36,9 +36,9 @@ export const PlayerCard = () => {
           </div>
           <Button onClick={isPlaying ? pause : play} variant="ghost">
             {isPlaying ? (
-              <Pause fill="#fff" size={20} />
+              <Pause fill="#fff" className="size-5" />
             ) : (
-              <Play fill="#fff" size={30} />
+              <Play fill="#fff" className="size-5" />
             )}
           </Button>
         </div>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SliderPrimitive from "@radix-ui/react-slider"
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
 
-import { cn } from "~/lib/utils"
+import { cn } from "~/lib/utils";
 
 function Slider({
   className,
@@ -11,8 +11,11 @@ function Slider({
   value,
   min = 0,
   max = 100,
+  thumbClassName,
   ...props
-}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+}: React.ComponentProps<typeof SliderPrimitive.Root> & {
+  thumbClassName?: string;
+}) {
   const _values = React.useMemo(
     () =>
       Array.isArray(value)
@@ -20,8 +23,8 @@ function Slider({
         : Array.isArray(defaultValue)
           ? defaultValue
           : [min, max],
-    [value, defaultValue, min, max]
-  )
+    [value, defaultValue, min, max],
+  );
 
   return (
     <SliderPrimitive.Root
@@ -32,20 +35,20 @@ function Slider({
       max={max}
       className={cn(
         "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
-        className
+        className,
       )}
       {...props}
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
         className={cn(
-          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
         )}
       >
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
           )}
         />
       </SliderPrimitive.Track>
@@ -53,11 +56,14 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className={cn(
+            "border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50",
+            thumbClassName,
+          )}
         />
       ))}
     </SliderPrimitive.Root>
-  )
+  );
 }
 
-export { Slider }
+export { Slider };


### PR DESCRIPTION
### TL;DR

various styling changes for the music player.

### What changed?

- `MusicPlayer.tsx` Added a translucent background with blur effect to the desktop music player (for when it overlays something)
- `PlaybackControl` filled the icons, made play/pause slightly larger
- `ProgressBar` removed the circle for scrubbing, adjusted gapping
- `VolumeControl` adjusted gapping, removed circle from slider, made it sit on top of the player
- `PlayerCard` icon sizing
- `Slider.tsx` updated shadcn component to accept thumbClassName for overriding.

### 