### PR TITLE
mobile player sheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "sonner": "^2.0.7",
         "superjson": "^2.2.1",
         "tailwind-merge": "^3.3.1",
+        "vaul": "^1.1.2",
         "zod": "^3.25.76",
         "zustand": "^5.0.8"
       },
@@ -9734,6 +9735,19 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sonner": "^2.0.7",
     "superjson": "^2.2.1",
     "tailwind-merge": "^3.3.1",
+    "vaul": "^1.1.2",
     "zod": "^3.25.76",
     "zustand": "^5.0.8"
   },

--- a/src/app/_components/player/components/desktop/ProgressBar.tsx
+++ b/src/app/_components/player/components/desktop/ProgressBar.tsx
@@ -6,6 +6,7 @@ interface ProgressBarProps {
   duration: number;
   onProgressChange: (value: number[]) => void;
   onProgressCommit: (value: number[]) => void;
+  location?: "desktop" | "mobile";
 }
 
 export const ProgressBar = ({
@@ -13,16 +14,23 @@ export const ProgressBar = ({
   duration,
   onProgressChange,
   onProgressCommit,
+  location = "desktop",
 }: ProgressBarProps) => {
   return (
-    <div className="flex flex-row items-center gap-4">
+    <div
+      className={
+        location === "desktop"
+          ? "flex flex-row items-center gap-4"
+          : "flex flex-col-reverse"
+      }
+    >
       <Slider
         value={[currentTime]}
         onValueChange={onProgressChange}
         onValueCommit={onProgressCommit}
         max={duration}
         step={1}
-        className="w-100"
+        className={location === "desktop" ? "w-80" : "w-full"}
         thumbClassName="hidden"
       />
 

--- a/src/app/_components/player/components/mobile/PlayerCard.tsx
+++ b/src/app/_components/player/components/mobile/PlayerCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card } from "~/components/ui/card";
+import { useState } from "react";
 import { useMusicPlayer } from "~/app/_components/player/useMusicPlayer";
 import {
   useMusicPlayerStore,
@@ -9,8 +10,10 @@ import {
 import { Progress } from "~/components/ui/progress";
 import { Button } from "~/components/ui/button";
 import { Play, Pause } from "lucide-react";
+import { PlayerSheet } from "./PlayerSheet";
 
 export const PlayerCard = () => {
+  const [open, setOpen] = useState(false);
   const { loadedOnce, isPlaying, duration, currentTime } =
     useMusicPlayerStore();
 
@@ -21,33 +24,49 @@ export const PlayerCard = () => {
   if (!loadedOnce) return null;
 
   return (
-    <Card className="position: fixed bottom-0 w-full rounded-none p-0">
-      <div className="flex h-full flex-col">
-        <div className="flex flex-row items-center justify-between px-6 py-3">
-          <div>
-            <p className="line-clamp-1 truncate font-semibold">
-              {currentTrack?.title}
-            </p>
-            <p className="text-muted-foreground line-clamp-1 truncate text-sm">
-              {currentTrack?.artists
-                .map((artist) => artist.artistName)
-                .join(", ")}
-            </p>
+    <>
+      <Card
+        className="position: fixed bottom-0 w-full rounded-none p-0"
+        onClick={() => setOpen(true)}
+      >
+        <div className="flex h-full flex-col">
+          <div className="flex flex-row items-center justify-between px-6 py-3">
+            <div>
+              <p className="line-clamp-1 truncate font-semibold">
+                {currentTrack?.title}
+              </p>
+              <p className="text-muted-foreground line-clamp-1 truncate text-sm">
+                {currentTrack?.artists
+                  .map((artist) => artist.artistName)
+                  .join(", ")}
+              </p>
+            </div>
+            <Button
+              onClick={async (e) => {
+                e.stopPropagation();
+                if (isPlaying) {
+                  await pause();
+                } else {
+                  await play();
+                }
+              }}
+              variant="ghost"
+            >
+              {isPlaying ? (
+                <Pause fill="#fff" className="size-5" />
+              ) : (
+                <Play fill="#fff" className="size-5" />
+              )}
+            </Button>
           </div>
-          <Button onClick={isPlaying ? pause : play} variant="ghost">
-            {isPlaying ? (
-              <Pause fill="#fff" className="size-5" />
-            ) : (
-              <Play fill="#fff" className="size-5" />
-            )}
-          </Button>
-        </div>
 
-        <Progress
-          value={(currentTime / duration) * 100}
-          className="rounded-none"
-        />
-      </div>
-    </Card>
+          <Progress
+            value={(currentTime / duration) * 100}
+            className="rounded-none"
+          />
+        </div>
+      </Card>
+      <PlayerSheet open={open} onOpenChange={setOpen} />
+    </>
   );
 };

--- a/src/app/_components/player/components/mobile/PlayerSheet.tsx
+++ b/src/app/_components/player/components/mobile/PlayerSheet.tsx
@@ -1,0 +1,76 @@
+import { Drawer, DrawerContent, DrawerTitle } from "~/components/ui/drawer";
+import { useMusicPlayer } from "~/app/_components/player/useMusicPlayer";
+import {
+  useMusicPlayerStore,
+  useMusicPlayerComputed,
+} from "~/app/_components/player/MusicPlayerStore";
+import { Button } from "~/components/ui/button";
+import { Play, Pause, SkipForward, SkipBack } from "lucide-react";
+import { ProgressBar } from "~/app/_components/player/components/desktop/ProgressBar";
+
+export const PlayerSheet = ({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { isPlaying, duration, currentTime } = useMusicPlayerStore();
+
+  const {
+    play,
+    pause,
+    next,
+    previous,
+    handleProgressChange,
+    handleProgressCommit,
+  } = useMusicPlayer();
+
+  const { currentTrack } = useMusicPlayerComputed();
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange} direction="bottom">
+      <DrawerContent>
+        <div className="hidden">
+          <DrawerTitle>Player</DrawerTitle>
+        </div>
+        <div className="flex h-screen flex-col justify-between px-4 py-8">
+          <div className="flex flex-col">
+            <p className="line-clamp-1 truncate font-semibold">
+              {currentTrack?.title}
+            </p>
+            <p className="text-muted-foreground line-clamp-1 truncate text-sm">
+              {currentTrack?.artists
+                .map((artist) => artist.artistName)
+                .join(", ")}
+            </p>
+          </div>
+          <div className="align-center flex justify-between">
+            <Button variant="ghost" onClick={previous}>
+              <SkipBack className="size-5" fill="#fff" />
+            </Button>
+            <Button variant="ghost" onClick={isPlaying ? pause : play}>
+              {isPlaying ? (
+                <Pause className="size-5" fill="#fff" />
+              ) : (
+                <Play className="size-5" fill="#fff" />
+              )}
+            </Button>
+            <Button variant="ghost" onClick={next}>
+              <SkipForward className="size-5" fill="#fff" />
+            </Button>
+          </div>
+          <div>
+            <ProgressBar
+              currentTime={currentTime}
+              duration={duration}
+              onProgressChange={handleProgressChange}
+              onProgressCommit={handleProgressCommit}
+              location="mobile"
+            />
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "~/lib/utils";
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      >
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};


### PR DESCRIPTION
### TL;DR

Added a mobile player sheet with full controls that opens when tapping the mini player.

### What changed?

- Implemented a `PlayerSheet` component that displays when tapping the mini player
- Enhanced the `ProgressBar` component to support both desktop and mobile layouts
- Updated the `PlayerCard` component to trigger the sheet when clicked

### How to test?

1. Play a track on a mobile device or in a mobile viewport
2. Tap on the mini player at the bottom of the screen
3. Verify the full player sheet slides up from the bottom
4. Test the playback controls (play/pause, next, previous)
5. Test the progress bar functionality
6. Verify the sheet closes properly when dragging down

### Why make this change?

This improves the mobile user experience by providing a full-screen player with more controls and information when needed, while maintaining a compact mini player for normal browsing. The drawer pattern is a common mobile UI pattern that feels natural to users and provides a more immersive music playback experience.