### PR TITLE
ridding spotify error noise

### DIFF
--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -50,6 +50,12 @@ export function useMusicPlayer() {
     };
     document.head.appendChild(ytScript);
 
+    // blank setup to get rid of noise, override later
+    if (typeof window !== "undefined" && !window.onSpotifyWebPlaybackSDKReady) {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      window.onSpotifyWebPlaybackSDKReady = () => {};
+    }
+
     const spotifyScript = document.createElement("script");
     spotifyScript.src = "https://sdk.scdn.co/spotify-player.js";
     spotifyScript.async = true;


### PR DESCRIPTION
### TL;DR

Added a blank setup function for Spotify Web Playback SDK to eliminate noise.

### What changed?

Added a conditional check that creates an empty `onSpotifyWebPlaybackSDKReady` function on the window object if it doesn't already exist. This is done before loading the Spotify script to prevent noise in the console.

### Why make this change?

This change prevents potential noise or errors in the console by ensuring that a handler for the Spotify Web Playback SDK's ready event exists before the SDK loads. The empty function serves as a placeholder that will be overridden later with the actual implementation, providing a cleaner initialization process.