### PR TITLE
track options, playlist control submenu

### DIFF
--- a/src/app/_components/TrackOptions.tsx
+++ b/src/app/_components/TrackOptions.tsx
@@ -8,6 +8,10 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuPortal,
 } from "~/components/ui/dropdown-menu";
 
 import { EditTrack } from "./forms/EditTrack";
@@ -96,14 +100,21 @@ export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
               <DropdownMenuSeparator />
             </>
           )}
-          <PlaylistSelector
-            options={formattedPlaylists ?? []}
-            selected={selectedPlaylists}
-            onChange={(selectedPlaylists) => {
-              handleUpdateTrackPlaylists(selectedPlaylists);
-            }}
-            className="mt-2"
-          />
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>playlists</DropdownMenuSubTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent>
+                <PlaylistSelector
+                  options={formattedPlaylists ?? []}
+                  selected={selectedPlaylists}
+                  onChange={(selectedPlaylists) => {
+                    handleUpdateTrackPlaylists(selectedPlaylists);
+                  }}
+                  className="mt-2"
+                />
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
         </DropdownMenuContent>
       </DropdownMenu>
       {open && <EditTrack open={open} onOpenChange={setOpen} song={song} />}


### PR DESCRIPTION
### TL;DR

Improved the playlist selection UI by moving it into a submenu within the track options dropdown.

### What changed?

- Wrapped the `PlaylistSelector` component in a dropdown submenu structure
- Added imports for the necessary dropdown submenu components:
    - `DropdownMenuSub`
    - `DropdownMenuSubTrigger`
    - `DropdownMenuSubContent`
    - `DropdownMenuPortal`
- Added a "playlists" trigger button that opens the submenu containing the playlist selector

### 