### PR TITLE
ios media session hack maybe

### DIFF
--- a/src/app/_components/player/utils.ts
+++ b/src/app/_components/player/utils.ts
@@ -41,6 +41,7 @@ export const setMediaSessionMetadata = (metadata: MediaMetadataInit | null) => {
 
 // TODO: repetitive to useMusicPlayer, make an actions file
 // phase out useMusicPlayer
+// wrap all in try catches as well
 export const setupMediaSession = (metadata: MediaMetadataInit | null) => {
   if (!("mediaSession" in navigator)) return;
 
@@ -152,6 +153,60 @@ export const setupMediaSession = (metadata: MediaMetadataInit | null) => {
     })();
   });
   navigator.mediaSession.setActionHandler("previoustrack", () => {
+    void (async () => {
+      const state = useMusicPlayerStore.getState();
+      const hasPreviousTrack = state.currentTrackIndex > 0;
+      if (state.currentPlaylist && state.controller && hasPreviousTrack) {
+        if (state.currentTime > 3) {
+          await state.controller.seekTo(0);
+          state.setCurrentTime(0);
+        } else {
+          pauseAnchorAudio();
+          state.setCurrentTrackIndex(state.currentTrackIndex - 1);
+          state.setCurrentTime(0.01);
+          state.setDuration(0.9);
+          await state.controller.previousTrack();
+          await state.controller.setVolume(state.volume);
+          state.setDuration(state.controller.duration);
+          state.setIsPlaying(true);
+
+          setTimeout(() => {
+            void startAnchorAudio();
+            const metadata = state.controller?.getMediaMetadata() ?? null;
+            setMediaSessionMetadata(metadata);
+          }, 1500);
+        }
+      }
+    })();
+  });
+  // ios is just displaying the 10 second seeks, override to next and previous track flow
+  navigator.mediaSession.setActionHandler("seekforward", () => {
+    void (async () => {
+      const state = useMusicPlayerStore.getState();
+      const hasNextTrack = state.currentPlaylist
+        ? state.currentTrackIndex < state.currentPlaylist.length - 1
+        : false;
+      if (state.currentPlaylist && state.controller && hasNextTrack) {
+        pauseAnchorAudio();
+        await state.controller.pause();
+        state.setIsPlaying(false);
+        state.setCurrentTrackIndex(state.currentTrackIndex + 1);
+        state.setCurrentTime(0.01);
+        state.setDuration(0.9);
+        await state.controller.nextTrack();
+        await state.controller.setVolume(state.volume);
+        state.setDuration(state.controller.duration);
+        state.setIsPlaying(true);
+
+        setTimeout(() => {
+          void startAnchorAudio();
+          const metadata = state.controller?.getMediaMetadata() ?? null;
+          setMediaSessionMetadata(metadata);
+        }, 1500);
+      }
+    })();
+  });
+  navigator.mediaSession.setActionHandler("seekbackward", () => {
     void (async () => {
       const state = useMusicPlayerStore.getState();
       const hasPreviousTrack = state.currentTrackIndex > 0;


### PR DESCRIPTION
### TL;DR

Added media session handlers for seek forward and backward actions on iOS devices to navigate between tracks instead of seeking within tracks.

### What changed?

- Added media session action handlers for `seekforward` and `seekbackward` actions
- Overrode the default 10-second seek behavior on iOS to instead navigate to next and previous tracks
- For `seekforward`, implemented logic to play the next track in the playlist
- For `seekbackward`, implemented logic to either restart the current track (if more than 3 seconds in) or play the previous track
- Added a comment about wrapping all handlers in try-catch blocks

### How to test?

1. Test on an iOS device with the media controls visible
2. Play a track in a playlist
3. Use the seek forward button to verify it plays the next track instead of seeking forward 10 seconds
4. Use the seek backward button to verify it:
   - Restarts the current track if more than 3 seconds into playback
   - Plays the previous track if less than 3 seconds into playback

### Why make this change?

iOS was displaying the 10-second seek controls by default, which provided a suboptimal user experience. This change improves the media control experience on iOS by making the seek buttons behave like next/previous track controls, which is more intuitive for music playback and matches the behavior on other platforms.