### PR TITLE
zustand selector refactor

### DIFF
--- a/src/app/_components/player/MusicPlayerStore.ts
+++ b/src/app/_components/player/MusicPlayerStore.ts
@@ -32,11 +32,6 @@ interface MusicPlayerState {
   setIsSeeking: (isSeeking: boolean) => void;
   setLoadedOnce: (loadedOnce: boolean) => void;
   setController: (controller: AudioController) => void;
-
-  // computed values
-  currentTrack: PlaylistTrack | null;
-  hasNextTrack: boolean;
-  hasPreviousTrack: boolean;
 }
 
 export const useMusicPlayerStore = create<MusicPlayerState>()(
@@ -83,7 +78,8 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
 
 // computed getters didn't work with devtools, so moving outside
 export const useMusicPlayerComputed = () => {
-  const { currentPlaylist, currentTrackIndex } = useMusicPlayerStore();
+  const currentPlaylist = useMusicPlayerStore((s) => s.currentPlaylist);
+  const currentTrackIndex = useMusicPlayerStore((s) => s.currentTrackIndex);
 
   return {
     currentTrack: currentPlaylist?.[currentTrackIndex] ?? null,

--- a/src/app/_components/player/components/desktop/MusicPlayer.tsx
+++ b/src/app/_components/player/components/desktop/MusicPlayer.tsx
@@ -7,11 +7,10 @@ import { VolumeControl } from "./VolumeControl";
 import {
   useMusicPlayerStore,
   useMusicPlayerComputed,
-} from "../../MusicPlayerStore";
+} from "~/app/_components/player/MusicPlayerStore";
 
 export const MusicPlayer = () => {
-  const { loadedOnce, isPlaying, volume, duration, currentTime } =
-    useMusicPlayerStore();
+  const loadedOnce = useMusicPlayerStore((s) => s.loadedOnce);
 
   const {
     play,
@@ -30,7 +29,6 @@ export const MusicPlayer = () => {
   return (
     <div className="bg-background/40 fixed bottom-10 left-1/2 z-100 flex -translate-x-1/2 items-center gap-4 rounded-full p-4 backdrop-blur-[2px]">
       <PlaybackControl
-        isPlaying={isPlaying}
         onPlay={play}
         onPause={pause}
         onNext={next}
@@ -48,13 +46,11 @@ export const MusicPlayer = () => {
           </p>
         </div>
         <ProgressBar
-          currentTime={currentTime}
-          duration={duration}
           onProgressChange={handleProgressChange}
           onProgressCommit={handleProgressCommit}
         />
       </div>
-      <VolumeControl volume={volume} onVolumeChange={handleVolumeChange} />
+      <VolumeControl onVolumeChange={handleVolumeChange} />
     </div>
   );
 };

--- a/src/app/_components/player/components/desktop/PlaybackControl.tsx
+++ b/src/app/_components/player/components/desktop/PlaybackControl.tsx
@@ -1,8 +1,11 @@
 import { Button } from "~/components/ui/button";
 import { Play, Pause, SkipForward, SkipBack } from "lucide-react";
+import {
+  useMusicPlayerStore,
+  useMusicPlayerComputed,
+} from "~/app/_components/player/MusicPlayerStore";
 
 interface PlaybackControlProps {
-  isPlaying: boolean;
   onPlay: () => void;
   onPause: () => void;
   onNext: () => void;
@@ -10,12 +13,14 @@ interface PlaybackControlProps {
 }
 
 export const PlaybackControl = ({
-  isPlaying,
   onPlay,
   onPause,
   onNext,
   onPrevious,
 }: PlaybackControlProps) => {
+  const isPlaying = useMusicPlayerStore((s) => s.isPlaying);
+  const { hasNextTrack } = useMusicPlayerComputed();
+
   return (
     <div className="flex flex-row gap-2">
       <Button onClick={onPrevious} variant="ghost">
@@ -34,7 +39,7 @@ export const PlaybackControl = ({
         )}
       </Button>
 
-      <Button onClick={onNext} variant="ghost">
+      <Button onClick={onNext} variant="ghost" disabled={!hasNextTrack}>
         <SkipForward className="h-4 w-4" fill="#fff" />
       </Button>
     </div>

--- a/src/app/_components/player/components/desktop/ProgressBar.tsx
+++ b/src/app/_components/player/components/desktop/ProgressBar.tsx
@@ -1,21 +1,21 @@
 import { Slider } from "~/components/ui/slider";
 import { formatSongTime } from "~/lib/utils";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 
 interface ProgressBarProps {
-  currentTime: number;
-  duration: number;
   onProgressChange: (value: number[]) => void;
   onProgressCommit: (value: number[]) => void;
   location?: "desktop" | "mobile";
 }
 
 export const ProgressBar = ({
-  currentTime,
-  duration,
   onProgressChange,
   onProgressCommit,
   location = "desktop",
 }: ProgressBarProps) => {
+  const currentTime = useMusicPlayerStore((s) => s.currentTime);
+  const duration = useMusicPlayerStore((s) => s.duration);
+
   return (
     <div
       className={

--- a/src/app/_components/player/components/desktop/VolumeControl.tsx
+++ b/src/app/_components/player/components/desktop/VolumeControl.tsx
@@ -6,16 +6,15 @@ import {
   PopoverTrigger,
 } from "~/components/ui/popover";
 import { Volume2 } from "lucide-react";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 
 interface VolumeControlProps {
-  volume: number;
   onVolumeChange: (value: number[]) => void;
 }
 
-export const VolumeControl = ({
-  volume,
-  onVolumeChange,
-}: VolumeControlProps) => {
+export const VolumeControl = ({ onVolumeChange }: VolumeControlProps) => {
+  const volume = useMusicPlayerStore((s) => s.volume);
+
   return (
     <Popover>
       <PopoverTrigger asChild>

--- a/src/app/_components/player/components/mobile/PlayerCard.tsx
+++ b/src/app/_components/player/components/mobile/PlayerCard.tsx
@@ -11,14 +11,20 @@ import { Progress } from "~/components/ui/progress";
 import { Button } from "~/components/ui/button";
 import { Play, Pause } from "lucide-react";
 import { PlayerSheet } from "./PlayerSheet";
+import { useShallow } from "zustand/react/shallow";
 
 export const PlayerCard = () => {
   const [open, setOpen] = useState(false);
-  const { loadedOnce, isPlaying, duration, currentTime } =
-    useMusicPlayerStore();
+  const { loadedOnce, isPlaying, duration, currentTime } = useMusicPlayerStore(
+    useShallow((s) => ({
+      loadedOnce: s.loadedOnce,
+      isPlaying: s.isPlaying,
+      duration: s.duration,
+      currentTime: s.currentTime,
+    })),
+  );
 
   const { play, pause } = useMusicPlayer();
-
   const { currentTrack } = useMusicPlayerComputed();
 
   if (!loadedOnce) return null;

--- a/src/app/_components/player/components/mobile/PlayerSheet.tsx
+++ b/src/app/_components/player/components/mobile/PlayerSheet.tsx
@@ -15,7 +15,7 @@ export const PlayerSheet = ({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) => {
-  const { isPlaying, duration, currentTime } = useMusicPlayerStore();
+  const isPlaying = useMusicPlayerStore((s) => s.isPlaying);
 
   const {
     play,
@@ -26,7 +26,7 @@ export const PlayerSheet = ({
     handleProgressCommit,
   } = useMusicPlayer();
 
-  const { currentTrack } = useMusicPlayerComputed();
+  const { currentTrack, hasNextTrack } = useMusicPlayerComputed();
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange} direction="bottom">
@@ -56,14 +56,12 @@ export const PlayerSheet = ({
                 <Play className="size-5" fill="#fff" />
               )}
             </Button>
-            <Button variant="ghost" onClick={next}>
+            <Button variant="ghost" onClick={next} disabled={!hasNextTrack}>
               <SkipForward className="size-5" fill="#fff" />
             </Button>
           </div>
           <div>
             <ProgressBar
-              currentTime={currentTime}
-              duration={duration}
               onProgressChange={handleProgressChange}
               onProgressCommit={handleProgressCommit}
               location="mobile"

--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -249,7 +249,7 @@ export function useMusicPlayer() {
   ]);
 
   const previous = useCallback(async () => {
-    if (currentPlaylist && hasPreviousTrack && controller) {
+    if (currentPlaylist && controller) {
       // user expectation, if into the song, hitting previous should go back to the start
       // if at the start, go previous track
       if (currentTime > 3) {
@@ -258,24 +258,26 @@ export function useMusicPlayer() {
         return;
       }
 
-      pauseAnchorAudio();
+      if (hasPreviousTrack) {
+        pauseAnchorAudio();
 
-      setCurrentTrackIndex(currentTrackIndex - 1);
+        setCurrentTrackIndex(currentTrackIndex - 1);
 
-      setCurrentTime(0.01);
-      setDuration(0.9);
+        setCurrentTime(0.01);
+        setDuration(0.9);
 
-      await controller.previousTrack();
-      await controller.setVolume(volume);
-      setDuration(controller.duration);
-      setIsPlaying(true);
+        await controller.previousTrack();
+        await controller.setVolume(volume);
+        setDuration(controller.duration);
+        setIsPlaying(true);
 
-      setTimeout(() => {
-        void startAnchorAudio();
-        const currentController = useMusicPlayerStore.getState().controller;
-        const metadata = currentController?.getMediaMetadata() ?? null;
-        setupMediaSession(metadata);
-      }, 1500);
+        setTimeout(() => {
+          void startAnchorAudio();
+          const currentController = useMusicPlayerStore.getState().controller;
+          const metadata = currentController?.getMediaMetadata() ?? null;
+          setupMediaSession(metadata);
+        }, 1500);
+      }
     }
   }, [
     controller,

--- a/src/app/_components/player/utils.ts
+++ b/src/app/_components/player/utils.ts
@@ -156,11 +156,11 @@ export const setupMediaSession = (metadata: MediaMetadataInit | null) => {
     void (async () => {
       const state = useMusicPlayerStore.getState();
       const hasPreviousTrack = state.currentTrackIndex > 0;
-      if (state.currentPlaylist && state.controller && hasPreviousTrack) {
+      if (state.currentPlaylist && state.controller) {
         if (state.currentTime > 3) {
           await state.controller.seekTo(0);
           state.setCurrentTime(0);
-        } else {
+        } else if (hasPreviousTrack) {
           pauseAnchorAudio();
           state.setCurrentTrackIndex(state.currentTrackIndex - 1);
           state.setCurrentTime(0.01);
@@ -210,11 +210,11 @@ export const setupMediaSession = (metadata: MediaMetadataInit | null) => {
     void (async () => {
       const state = useMusicPlayerStore.getState();
       const hasPreviousTrack = state.currentTrackIndex > 0;
-      if (state.currentPlaylist && state.controller && hasPreviousTrack) {
+      if (state.currentPlaylist && state.controller) {
         if (state.currentTime > 3) {
           await state.controller.seekTo(0);
           state.setCurrentTime(0);
-        } else {
+        } else if (hasPreviousTrack) {
           pauseAnchorAudio();
           state.setCurrentTrackIndex(state.currentTrackIndex - 1);
           state.setCurrentTime(0.01);

--- a/src/app/library/components/DataTablePlay.tsx
+++ b/src/app/library/components/DataTablePlay.tsx
@@ -10,10 +10,18 @@ import { useMusicPlayer } from "~/app/_components/player/useMusicPlayer";
 import { Button } from "~/components/ui/button";
 import Lottie from "lottie-react";
 import SoundWave from "~/app/playlist/[id]/SoundWave.json";
+import { useShallow } from "zustand/react/shallow";
 
 export const DataTablePlay = ({ song }: { song: LibraryTrack }) => {
   const { currentPlaylistId, setCurrentPlaylist, setCurrentTrackIndex } =
-    useMusicPlayerStore();
+    useMusicPlayerStore(
+      useShallow((s) => ({
+        currentPlaylistId: s.currentPlaylistId,
+        setCurrentPlaylist: s.setCurrentPlaylist,
+        setCurrentTrackIndex: s.setCurrentTrackIndex,
+      })),
+    );
+
   const { currentTrack } = useMusicPlayerComputed();
   const { play } = useMusicPlayer();
   const LIBRARY_PLAYLIST_ID = -1;

--- a/src/app/playlist/[id]/PlaylistItem.tsx
+++ b/src/app/playlist/[id]/PlaylistItem.tsx
@@ -9,6 +9,7 @@ import { TrackOptions } from "~/app/_components/TrackOptions";
 import Lottie from "lottie-react";
 import SoundWave from "./SoundWave.json";
 import Link from "next/link";
+import { useShallow } from "zustand/react/shallow";
 
 interface PlaylistItemProps {
   index: number;
@@ -34,7 +35,14 @@ export const PlaylistItem = ({
     currentTrackIndex,
     setCurrentPlaylist,
     setCurrentTrackIndex,
-  } = useMusicPlayerStore();
+  } = useMusicPlayerStore(
+    useShallow((s) => ({
+      currentPlaylistId: s.currentPlaylistId,
+      currentTrackIndex: s.currentTrackIndex,
+      setCurrentPlaylist: s.setCurrentPlaylist,
+      setCurrentTrackIndex: s.setCurrentTrackIndex,
+    })),
+  );
 
   const { play } = useMusicPlayer();
 
@@ -78,7 +86,7 @@ export const PlaylistItem = ({
                 <Link
                   href={`/artists/${artist.artistId}`}
                   key={artist.artistId}
-                  className="hover:underline"
+                  className="text-muted-foreground hover:underline"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {artist.artistName}


### PR DESCRIPTION
### TL;DR

Refactored music player components to use selective state subscriptions to zustand for proper performance. Before I was unintentionally subscribing to the entire store when I thought I was just grabbing the relevant values. Should cut down on re-renders a great amount. Also fractured out some components and the state they were listening to. IE `musicPlayer.tsx` was subscribing to everything for the components it amalgamated cause full re-renders. Now each component below just listens to what they need. 

### What changed?

- Removed computed values from the main store interface and moved them to the `useMusicPlayerComputed` hook (improper association, they weren't on the store)
- Implemented selective state subscriptions using Zustand selectors in all player components
- Added `useShallow` from Zustand in some components that grabbed a bunch of values
- Fixed previous track functionality to properly handle edge cases
- Added disabled state to next track button when there are no more tracks
- Improved styling for artist links in playlist items

### How to test?

1. Play music and verify that playback controls work correctly
2. Test the previous track button behavior:
    - When less than 3 seconds into a track, it should go to the previous track
    - When more than 3 seconds into a track, it should restart the current track
3. Verify that the next track button is disabled when at the end of a playlist
4. Check that the player UI updates correctly when changing tracks

### Why make this change?

This refactoring improves performance by preventing unnecessary re-renders when the music player state changes. By using Zustand selectors, components only re-render when the specific state they depend on changes, rather than when any part of the store updates. This is particularly important for a music player that has frequently changing state like current time and playback status.