### PR TITLE
moving script loading out of usemusicplayer

### DIFF
--- a/src/app/_components/player/components/MediaSessionAnchor.tsx
+++ b/src/app/_components/player/components/MediaSessionAnchor.tsx
@@ -1,6 +1,14 @@
 "use client";
 
+import { useEffect } from "react";
+import { loadPlayerScripts } from "~/app/_components/player/utils";
+
 export const AppMediaAnchor = () => {
+  useEffect(() => {
+    const cleanup = loadPlayerScripts();
+    return cleanup;
+  }, []);
+
   return (
     <>
       <audio

--- a/src/app/_components/player/useMusicPlayer.ts
+++ b/src/app/_components/player/useMusicPlayer.ts
@@ -30,57 +30,6 @@ export function useMusicPlayer() {
 
   const { hasNextTrack, hasPreviousTrack } = useMusicPlayerComputed();
 
-  // load scripts
-  useEffect(() => {
-    const scScript = document.createElement("script");
-    scScript.src = "https://w.soundcloud.com/player/api.js";
-    scScript.async = true;
-    scScript.onload = () => {
-      // eslint-disable-next-line no-console
-      console.log("SoundCloud API loaded");
-    };
-    document.head.appendChild(scScript);
-
-    const ytScript = document.createElement("script");
-    ytScript.src = "https://www.youtube.com/iframe_api";
-    ytScript.async = true;
-    ytScript.onload = () => {
-      // eslint-disable-next-line no-console
-      console.log("YouTube API loaded");
-    };
-    document.head.appendChild(ytScript);
-
-    // blank setup to get rid of noise, override later
-    if (typeof window !== "undefined" && !window.onSpotifyWebPlaybackSDKReady) {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      window.onSpotifyWebPlaybackSDKReady = () => {};
-    }
-
-    const spotifyScript = document.createElement("script");
-    spotifyScript.src = "https://sdk.scdn.co/spotify-player.js";
-    spotifyScript.async = true;
-    spotifyScript.onload = () => {
-      // eslint-disable-next-line no-console
-      console.log("Spotify API loaded");
-    };
-    document.body.appendChild(spotifyScript);
-
-    return () => {
-      const sc = document.querySelector(
-        'script[src="https://w.soundcloud.com/player/api.js"]',
-      );
-      const yt = document.querySelector(
-        'script[src="https://www.youtube.com/iframe_api"]',
-      );
-      const sp = document.querySelector(
-        'script[src="https://sdk.scdn.co/spotify-player.js"]',
-      );
-      if (sc) document.head.removeChild(sc);
-      if (yt) document.head.removeChild(yt);
-      if (sp) document.body.removeChild(sp);
-    };
-  }, []);
-
   // timer to update current time
   useEffect(() => {
     let interval: NodeJS.Timeout;

--- a/src/app/_components/player/utils.ts
+++ b/src/app/_components/player/utils.ts
@@ -1,6 +1,57 @@
 import { AudioController } from "./AudioController";
 import { useMusicPlayerStore } from "./MusicPlayerStore";
 
+export const loadPlayerScripts = (): void | (() => void) => {
+  if (typeof document === "undefined") return () => undefined;
+
+  const scScript = document.createElement("script");
+  scScript.src = "https://w.soundcloud.com/player/api.js";
+  scScript.async = true;
+  scScript.onload = () => {
+    // eslint-disable-next-line no-console
+    console.log("SoundCloud API loaded");
+  };
+  document.head.appendChild(scScript);
+
+  const ytScript = document.createElement("script");
+  ytScript.src = "https://www.youtube.com/iframe_api";
+  ytScript.async = true;
+  ytScript.onload = () => {
+    // eslint-disable-next-line no-console
+    console.log("YouTube API loaded");
+  };
+  document.head.appendChild(ytScript);
+
+  if (typeof window !== "undefined" && !window.onSpotifyWebPlaybackSDKReady) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    window.onSpotifyWebPlaybackSDKReady = () => {};
+  }
+
+  const spotifyScript = document.createElement("script");
+  spotifyScript.src = "https://sdk.scdn.co/spotify-player.js";
+  spotifyScript.async = true;
+  spotifyScript.onload = () => {
+    // eslint-disable-next-line no-console
+    console.log("Spotify API loaded");
+  };
+  document.body.appendChild(spotifyScript);
+
+  return () => {
+    const sc = document.querySelector(
+      'script[src="https://w.soundcloud.com/player/api.js"]',
+    );
+    const yt = document.querySelector(
+      'script[src="https://www.youtube.com/iframe_api"]',
+    );
+    const sp = document.querySelector(
+      'script[src="https://sdk.scdn.co/spotify-player.js"]',
+    );
+    if (sc) document.head.removeChild(sc);
+    if (yt) document.head.removeChild(yt);
+    if (sp) document.body.removeChild(sp);
+  };
+};
+
 export const formatTime = (seconds: number) => {
   const mins = Math.floor(seconds / 60);
   const secs = Math.floor(seconds % 60);


### PR DESCRIPTION
### TL;DR

Moved player script loading logic from `useMusicPlayer` hook to a dedicated utility function that's called from `MediaSessionAnchor`.

### What changed?

- Extracted the script loading logic from `useMusicPlayer.ts` into a new utility function `loadPlayerScripts()` in `utils.ts`
- Added a `useEffect` hook in `MediaSessionAnchor.tsx` that calls this new utility function
- Removed the script loading logic from the `useMusicPlayer` hook
- Ensured proper cleanup of scripts in both implementations

### How to test?

1. Play music from different sources (YouTube, SoundCloud, Spotify)
2. Verify that the player APIs load correctly (check console logs for "API loaded" messages)
3. Confirm that media controls work as expected
4. Navigate between pages to ensure scripts are properly loaded and cleaned up

### Why make this change?

This refactoring improves code organization by:
1. Moving the script loading logic to a more appropriate component (`MediaSessionAnchor`)
2. Extracting the logic into a reusable utility function
3. Ensuring the player scripts are loaded only when needed
4. Making the `useMusicPlayer` hook more focused on player state management rather than script loading