### PR TITLE
readding albums

### DIFF
--- a/src/app/_components/forms/AddTrack.tsx
+++ b/src/app/_components/forms/AddTrack.tsx
@@ -84,13 +84,13 @@ export const AddTrack = ({
   const handleStep2Submit = (data: AddTrackFormData) => {
     const processedData = {
       title: data.title,
-      artist: data.artist.filter((name) => name.trim() !== ""), // Remove empty artist names
-      album: data.album?.trim() || undefined,
+      artist: data.artist,
+      album: data.album?.trim() || null,
       source: data.source,
       sourceId: data.sourceId,
       sourceUrl: data.sourceUrl,
-      artworkUrl: data.artworkUrl || undefined,
-      duration: data.duration || undefined,
+      artworkUrl: data.artworkUrl || null,
+      duration: data.duration ?? null, // 0
     };
 
     addTrackMutation.mutate(processedData);

--- a/src/app/_components/forms/EditTrack.tsx
+++ b/src/app/_components/forms/EditTrack.tsx
@@ -59,7 +59,8 @@ export const EditTrack = ({
       id: song.trackId,
       title: data.title,
       artist: data.artist,
-      album: data.album?.trim() || undefined,
+      album: data.album?.trim() || null,
+      artworkUrl: data.artworkUrl || null,
     };
 
     editTrackMutation.mutate(processedData);

--- a/src/app/_components/forms/TrackForm.tsx
+++ b/src/app/_components/forms/TrackForm.tsx
@@ -37,7 +37,7 @@ export const TrackForm = ({
 }) => {
   const form = useForm<AddTrackFormData>({
     defaultValues: {
-      album: "",
+      album: initialData.album || "",
       artist: initialData.artist ? initialData.artist : [],
       artworkUrl: initialData.artworkUrl,
       duration: initialData.duration,
@@ -119,8 +119,7 @@ export const TrackForm = ({
               </FormItem>
             )}
           />
-          {/* TODO: maybe include later */}
-          {/* <FormField
+          <FormField
             control={form.control}
             name="album"
             render={({ field }) => (
@@ -132,7 +131,9 @@ export const TrackForm = ({
               </FormItem>
             )}
           />
-          <p>Source: {initialData.source}</p> */}
+          <p className="text-muted-foreground text-xs">
+            Source: {initialData.source}
+          </p>
         </form>
       </Form>
     </div>

--- a/src/server/api/routers/tracks.ts
+++ b/src/server/api/routers/tracks.ts
@@ -1,17 +1,17 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
-import { type SongSource } from "@prisma/client";
+import { type Album, type SongSource } from "@prisma/client";
 
 export const tracksRouter = createTRPCRouter({
   addTrack: protectedProcedure
     .input(
       z.object({
-        album: z.string().optional(),
+        album: z.string().nullable(),
         artist: z
           .array(z.string().min(1, "Artist name cannot be empty"))
           .min(1, "At least one artist is required"),
-        artworkUrl: z.string().optional(),
-        duration: z.number().optional(),
+        artworkUrl: z.string().nullable(),
+        duration: z.number().nullable(),
         source: z.string(),
         sourceId: z.string(),
         sourceUrl: z.string(),
@@ -67,25 +67,29 @@ export const tracksRouter = createTRPCRouter({
         const artists = await Promise.all(artistPromises);
 
         // album
-        let album = await tx.album.findFirst({
-          where: {
-            name: input.album,
-          },
-        });
-
-        if (!album && input.album) {
-          album = await tx.album.create({
-            data: {
+        let album: Album | null = null;
+        if (input.album !== null && input.album !== "") {
+          album = await tx.album.findFirst({
+            where: {
               name: input.album,
             },
           });
+
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          if (!album) {
+            album = await tx.album.create({
+              data: {
+                name: input.album,
+              },
+            });
+          }
         }
 
         // library track
         const libraryTrack = await tx.libraryTrack.create({
           data: {
             title: input.title,
-            albumId: album?.id ?? undefined,
+            albumId: album?.id ?? null,
             trackId: track.id,
             userId,
           },
@@ -110,8 +114,8 @@ export const tracksRouter = createTRPCRouter({
         artist: z
           .array(z.string().min(1, "Artist name cannot be empty"))
           .min(1, "At least one artist is required"),
-        album: z.string().optional(),
-        artworkUrl: z.string().optional(),
+        album: z.string().nullable(),
+        artworkUrl: z.string().nullable(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -151,25 +155,29 @@ export const tracksRouter = createTRPCRouter({
         const artists = await Promise.all(artistPromises);
 
         // album
-        let album = await tx.album.findFirst({
-          where: {
-            name: input.album,
-          },
-        });
-
-        if (!album && input.album) {
-          album = await tx.album.create({
-            data: {
+        let album: Album | null = null;
+        if (input.album !== null && input.album !== "") {
+          album = await tx.album.findFirst({
+            where: {
               name: input.album,
             },
           });
+
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          if (!album) {
+            album = await tx.album.create({
+              data: {
+                name: input.album,
+              },
+            });
+          }
         }
 
         const updatedTrack = await tx.libraryTrack.update({
           where: { id: input.id, userId: userId },
           data: {
             title: input.title,
-            albumId: album?.id ?? undefined,
+            albumId: album?.id ?? null,
           },
         });
 

--- a/src/server/lib/spotify/fetchSpotifyTrackData.ts
+++ b/src/server/lib/spotify/fetchSpotifyTrackData.ts
@@ -76,7 +76,7 @@ export const fetchSpotifyTrackData = async ({
   return {
     title: data.name,
     artist: data.artists.map((artist) => artist.name),
-    album: "",
+    album: data.album.name ?? "",
     duration: data.duration_ms,
     artworkUrl: data.album.images[0]?.url ?? "",
     sourceUrl: url,


### PR DESCRIPTION
### TL;DR

Re-added albums to track adding and editing. Fixed track data handling to properly support null values for album, artworkUrl, and duration fields.

### What changed?

- Updated the schema to use `nullable()` instead of `optional()` for album, artworkUrl, and duration fields
- Fixed how empty albums are handled in both add and edit track functions
- Re-enabled the album input field in the track form UI
- Added proper null handling for artwork URLs
- Changed duration handling to use nullish coalescing (`??`) instead of logical OR (`||`)
- Added album name extraction from Spotify track data
- Added source display in the track form

### How to test?

1. Add a track with and without an album name
2. Edit a track and verify album and artwork fields work correctly
3. Add a Spotify track and verify the album name is populated correctly
4. Verify tracks with zero duration (0) are handled correctly

### Why make this change?

This change ensures consistent handling of nullable fields in the database and UI. Previously, empty strings and undefined values were being used inconsistently, which could cause data integrity issues. The change also improves the user experience by displaying the album field and source information in the track form.