### PR TITLE
context menu conditional rendering fix

### DIFF
--- a/src/app/_components/ContextMenu.tsx
+++ b/src/app/_components/ContextMenu.tsx
@@ -67,8 +67,12 @@ export const GlobalContextMenu = ({
         </ContextMenuContent>
       </ContextMenu>
 
-      <AddTrack open={addSongOpen} onOpenChange={setAddSongOpen} />
-      <AddPlaylist open={addPlaylistOpen} onOpenChange={setAddPlaylistOpen} />
+      {addSongOpen && (
+        <AddTrack open={addSongOpen} onOpenChange={setAddSongOpen} />
+      )}
+      {addPlaylistOpen && (
+        <AddPlaylist open={addPlaylistOpen} onOpenChange={setAddPlaylistOpen} />
+      )}
     </>
   );
 };


### PR DESCRIPTION
### TL;DR

Conditionally render AddTrack and AddPlaylist components only when they are open.

### What changed?

Modified the `GlobalContextMenu` component to wrap the `AddTrack` and `AddPlaylist` components in conditional rendering blocks. Now these components will only be rendered in the DOM when their respective `open` states are true.

### How to test?

1. Open the application and right-click to open the context menu
2. Select "Add Track" or "Add Playlist" options
3. Verify that the respective modals appear correctly
4. Close the modals and check that they're properly removed from the DOM

### Why make this change?

This optimization prevents unnecessary rendering of components when they're not visible to the user. By conditionally rendering these components only when needed, we can improve performance and reduce the number of elements in the DOM tree, especially important for complex components like modals.