### PR TITLE
shuffle play logic

### DIFF
--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -43,11 +43,15 @@ export class AudioController {
     this.currentAdapter = adapter;
   }
 
-  async loadPlaylist(playlist: PlaylistTrack[], index: number) {
+  async loadPlaylist(
+    playlist: PlaylistTrack[],
+    index: number,
+    skipTrackLoad: boolean = false,
+  ) {
     this.playlist = playlist;
     this.currentIndex = index;
 
-    if (this.playlist.length > 0) {
+    if (this.playlist.length > 0 && !skipTrackLoad) {
       await this.loadTrackByIndex(this.currentIndex);
     }
   }

--- a/src/app/_components/player/MusicPlayerStore.ts
+++ b/src/app/_components/player/MusicPlayerStore.ts
@@ -3,13 +3,20 @@ import { devtools } from "zustand/middleware";
 import type { PlaylistTrack } from "./types/player";
 import type { AudioController } from "./AudioController";
 
+type setPlaylistOptions = {
+  preservePlaybackState?: boolean;
+  newTrackIndex?: number;
+};
+
 interface MusicPlayerState {
   // playlist state
   currentPlaylist: PlaylistTrack[] | null;
+  originalPlaylist: PlaylistTrack[] | null;
   currentPlaylistId: number | null;
   currentTrackIndex: number;
 
   // player state
+  isShuffleOn: boolean;
   isPlaying: boolean;
   isLoaded: boolean;
   volume: number;
@@ -22,8 +29,14 @@ interface MusicPlayerState {
   controller: AudioController | null;
 
   // actions
-  setCurrentPlaylist: (playlist: PlaylistTrack[], playlistId: number) => void;
+  setCurrentPlaylist: (
+    playlist: PlaylistTrack[],
+    playlistId: number,
+    options?: setPlaylistOptions,
+  ) => void;
+  setOriginalPlaylist: (playlist: PlaylistTrack[]) => void;
   setCurrentTrackIndex: (trackIndex: number) => void;
+  setIsShuffleOn: (isShuffleOn: boolean) => void;
   setIsPlaying: (isPlaying: boolean) => void;
   setIsLoaded: (isLoaded: boolean) => void;
   setVolume: (volume: number) => void;
@@ -38,8 +51,10 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
   devtools(
     (set) => ({
       currentPlaylist: null,
+      originalPlaylist: null,
       currentPlaylistId: null,
       currentTrackIndex: 0,
+      isShuffleOn: false,
       isPlaying: false,
       isLoaded: false,
       volume: 100,
@@ -48,19 +63,35 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
       isSeeking: false,
       loadedOnce: false,
 
-      setCurrentPlaylist: (playlist: PlaylistTrack[], playlistId: number) =>
-        set({
-          currentPlaylist: playlist,
-          currentPlaylistId: playlistId,
-          currentTrackIndex: 0,
-          currentTime: 0,
-          duration: 0,
-          isLoaded: false,
-          isPlaying: false,
+      setCurrentPlaylist: (
+        playlist: PlaylistTrack[],
+        playlistId: number,
+        options?: setPlaylistOptions,
+      ) =>
+        set(() => {
+          const { preservePlaybackState = false, newTrackIndex } =
+            options ?? {};
+
+          return {
+            currentPlaylist: playlist,
+            currentPlaylistId: playlistId,
+            currentTrackIndex: newTrackIndex ?? 0,
+            ...(preservePlaybackState
+              ? {}
+              : {
+                  currentTime: 0,
+                  duration: 0,
+                  isLoaded: false,
+                  isPlaying: false,
+                }),
+          };
         }),
 
+      setOriginalPlaylist: (playlist: PlaylistTrack[]) =>
+        set({ originalPlaylist: playlist }),
       setCurrentTrackIndex: (index: number) =>
         set({ currentTrackIndex: index }),
+      setIsShuffleOn: (isShuffleOn: boolean) => set({ isShuffleOn }),
       setIsPlaying: (playing: boolean) => set({ isPlaying: playing }),
       setIsLoaded: (loaded: boolean) => set({ isLoaded: loaded }),
       setVolume: (volume: number) => set({ volume }),

--- a/src/app/_components/player/helpers/shuffleFunctions.ts
+++ b/src/app/_components/player/helpers/shuffleFunctions.ts
@@ -1,0 +1,96 @@
+import { useMusicPlayerStore } from "../MusicPlayerStore";
+import type { PlaylistTrack } from "../types/player";
+
+export const fisherYatesShuffle = <T>(array: T[]): T[] => {
+  const shuffled = [...array];
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!];
+  }
+  return shuffled;
+};
+
+/**
+ * Toggle shuffle from the playlist header or music player control
+ * If we don't have a currPlaylist, just updating the store
+ * If we do, swapping and updating the playlist state
+ */
+export const toggleShuffle = async () => {
+  const {
+    isShuffleOn,
+    setIsShuffleOn,
+    currentPlaylist,
+    setCurrentPlaylist,
+    currentPlaylistId,
+    controller,
+  } = useMusicPlayerStore.getState();
+
+  setIsShuffleOn(!isShuffleOn);
+
+  // Not an error state, don't want to do anything more if we don't have a current playlist
+  if (!currentPlaylist) return;
+
+  if (!currentPlaylistId || !controller) {
+    console.warn("No current playlist or controller, skipping shuffle toggle");
+    return;
+  }
+
+  if (isShuffleOn) {
+    const { playlist, trackIndex } =
+      restoreOriginalPlaylistWithCurrentPosition();
+    setCurrentPlaylist(playlist, currentPlaylistId, {
+      preservePlaybackState: true,
+      newTrackIndex: trackIndex,
+    });
+    await controller.loadPlaylist(playlist, trackIndex, true);
+  } else {
+    const shuffledPlaylist = reserveCurrentAndShuffleRest();
+    setCurrentPlaylist(shuffledPlaylist, currentPlaylistId, {
+      preservePlaybackState: true,
+    });
+    await controller.loadPlaylist(shuffledPlaylist, 0, true);
+  }
+};
+
+/**
+ * Reserve the current track, shuffle the rest of the playlist, unshift reserved track, and return the shuffled playlist
+ */
+export const reserveCurrentAndShuffleRest = (): PlaylistTrack[] => {
+  const { currentPlaylist, currentTrackIndex } = useMusicPlayerStore.getState();
+
+  const currentTrackId = currentPlaylist![currentTrackIndex]!.trackId;
+  let currentTrackIndexInBasePlaylist = currentPlaylist!.findIndex(
+    (track) => track.trackId === currentTrackId,
+  );
+
+  if (currentTrackIndexInBasePlaylist === -1) {
+    currentTrackIndexInBasePlaylist = 0;
+  }
+
+  const reservedTrack = currentPlaylist![currentTrackIndexInBasePlaylist]!;
+  const playlistWithoutCurrentTrack = currentPlaylist!.filter(
+    (track) => track.trackId !== currentTrackId,
+  );
+  const shuffledRestOfPlaylist = fisherYatesShuffle(
+    playlistWithoutCurrentTrack,
+  );
+  const shuffledPlaylist = [reservedTrack, ...shuffledRestOfPlaylist];
+
+  return shuffledPlaylist;
+};
+
+const restoreOriginalPlaylistWithCurrentPosition = (): {
+  playlist: PlaylistTrack[];
+  trackIndex: number;
+} => {
+  const { currentPlaylist, currentTrackIndex, originalPlaylist } =
+    useMusicPlayerStore.getState();
+  const currentTrackId = currentPlaylist![currentTrackIndex]!.trackId;
+  const originalTrackIndex = originalPlaylist!.findIndex(
+    (track) => track.trackId === currentTrackId,
+  );
+  return {
+    playlist: originalPlaylist!,
+    trackIndex: originalTrackIndex,
+  };
+};

--- a/src/app/playlist/[id]/PlaylistHeader.tsx
+++ b/src/app/playlist/[id]/PlaylistHeader.tsx
@@ -1,22 +1,34 @@
 "use client";
-import { api } from "~/trpc/react";
-import { useState } from "react";
-import { Button } from "~/components/ui/button";
-import { Trash2, Pencil } from "lucide-react";
+import { Pencil, Play, Shuffle, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { ConfirmationDialog } from "~/app/_components/ConfirmationDialog";
-import { Input } from "~/components/ui/input";
+import { useState } from "react";
 import { toast } from "sonner";
+import { ConfirmationDialog } from "~/app/_components/ConfirmationDialog";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
+import {
+  fisherYatesShuffle,
+  toggleShuffle,
+} from "~/app/_components/player/helpers/shuffleFunctions";
+import { play } from "~/app/_components/player/musicPlayerActions";
+import type { PlaylistTrack } from "~/app/_components/player/types/player";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { api } from "~/trpc/react";
 
 export const PlaylistHeader = ({
   playlistId,
   playlistName,
+  playlist,
 }: {
   playlistId: number;
   playlistName: string;
+  playlist: PlaylistTrack[];
 }) => {
   const utils = api.useUtils();
   const router = useRouter();
+  const { setCurrentPlaylist, setCurrentTrackIndex, setOriginalPlaylist } =
+    useMusicPlayerStore.getState();
+  const isShuffleOn = useMusicPlayerStore((s) => s.isShuffleOn);
   const [hovered, setHovered] = useState(false);
   const [currentPlaylistName, setCurrentPlaylistName] = useState(playlistName);
   const [isEditing, setIsEditing] = useState(false);
@@ -49,39 +61,69 @@ export const PlaylistHeader = ({
     setIsEditing(false);
   };
 
+  const handlePlay = async () => {
+    setCurrentPlaylist(playlist, playlistId);
+    setOriginalPlaylist(playlist);
+    setCurrentTrackIndex(0);
+
+    if (isShuffleOn) {
+      const shuffledPlaylist = fisherYatesShuffle(playlist);
+      setCurrentPlaylist(shuffledPlaylist, playlistId, {
+        newTrackIndex: 0,
+      });
+    }
+
+    await play();
+  };
+
   return (
     <>
-      <div
-        className="mx-auto flex w-full max-w-120 items-center justify-between"
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
-      >
-        {isEditing ? (
-          <Input
-            defaultValue={currentPlaylistName}
-            onBlur={(e) => handleUpdatePlaylistName(e.target.value)}
-          />
-        ) : (
-          <h1 className="mt-7">{currentPlaylistName}</h1>
-        )}
-        {hovered && !isEditing && (
-          <div>
-            <Button
-              size="icon"
-              className="rounded-full"
-              onClick={() => setIsEditing(true)}
-            >
-              <Pencil />
-            </Button>
-            <Button
-              size="icon"
-              className="rounded-full"
-              onClick={() => setConfirmationDialogOpen(true)}
-            >
-              <Trash2 />
-            </Button>
-          </div>
-        )}
+      <div className="mx-auto mt-8 mb-4 flex w-full max-w-120 flex-col gap-2">
+        <div
+          className="flex justify-between"
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+        >
+          {isEditing ? (
+            <Input
+              defaultValue={currentPlaylistName}
+              onBlur={(e) => handleUpdatePlaylistName(e.target.value)}
+            />
+          ) : (
+            <h1>{currentPlaylistName}</h1>
+          )}
+          {hovered && !isEditing && (
+            <div>
+              <Button
+                size="icon"
+                className="rounded-full"
+                onClick={() => setIsEditing(true)}
+              >
+                <Pencil />
+              </Button>
+              <Button
+                size="icon"
+                className="rounded-full"
+                onClick={() => setConfirmationDialogOpen(true)}
+              >
+                <Trash2 />
+              </Button>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          {/* TODO */}
+          <Button
+            size="icon"
+            className={isShuffleOn ? "bg-amber-600" : "bg-primary"}
+            onClick={toggleShuffle}
+          >
+            <Shuffle />
+          </Button>
+          <Button size="icon" onClick={handlePlay}>
+            <Play />
+          </Button>
+        </div>
       </div>
       <ConfirmationDialog
         text="Are you sure you want to delete this playlist?"

--- a/src/app/playlist/[id]/PlaylistItem.tsx
+++ b/src/app/playlist/[id]/PlaylistItem.tsx
@@ -10,6 +10,7 @@ import SoundWave from "./SoundWave.json";
 import Link from "next/link";
 import { useShallow } from "zustand/react/shallow";
 import { play } from "~/app/_components/player/musicPlayerActions";
+import { reserveCurrentAndShuffleRest } from "~/app/_components/player/helpers/shuffleFunctions";
 
 interface PlaylistItemProps {
   index: number;
@@ -18,6 +19,7 @@ interface PlaylistItemProps {
   artists: { artistId: number; artistName: string }[];
   playlist: PlaylistTrack[];
   playlistId: number;
+  trackId: number;
 }
 
 export const PlaylistItem = ({
@@ -27,31 +29,37 @@ export const PlaylistItem = ({
   artists,
   playlist,
   playlistId,
+  trackId,
 }: PlaylistItemProps) => {
   const [hovered, setHovered] = useState(false);
 
-  const {
-    currentPlaylistId,
-    currentTrackIndex,
-    setCurrentPlaylist,
-    setCurrentTrackIndex,
-  } = useMusicPlayerStore(
-    useShallow((s) => ({
-      currentPlaylistId: s.currentPlaylistId,
-      currentTrackIndex: s.currentTrackIndex,
-      setCurrentPlaylist: s.setCurrentPlaylist,
-      setCurrentTrackIndex: s.setCurrentTrackIndex,
-    })),
-  );
+  const { currentPlaylistId, currentTrackIndex, currentPlaylist, isShuffleOn } =
+    useMusicPlayerStore(
+      useShallow((s) => ({
+        currentPlaylistId: s.currentPlaylistId,
+        currentTrackIndex: s.currentTrackIndex,
+        currentPlaylist: s.currentPlaylist,
+        isShuffleOn: s.isShuffleOn,
+      })),
+    );
+  const { setCurrentPlaylist, setCurrentTrackIndex, setOriginalPlaylist } =
+    useMusicPlayerStore.getState();
 
   const isCurrentTrack =
-    currentPlaylistId === playlistId && currentTrackIndex === index;
+    currentPlaylistId === playlistId &&
+    currentPlaylist![currentTrackIndex]!.trackId === trackId;
 
   const handlePlay = async () => {
-    if (currentPlaylistId !== playlistId) {
-      setCurrentPlaylist(playlist, playlistId);
-    }
+    setCurrentPlaylist(playlist, playlistId);
+    setOriginalPlaylist(playlist);
     setCurrentTrackIndex(index);
+
+    if (isShuffleOn) {
+      const shuffledPlaylist = reserveCurrentAndShuffleRest();
+      setCurrentPlaylist(shuffledPlaylist, playlistId, {
+        newTrackIndex: 0,
+      });
+    }
 
     await play();
   };

--- a/src/app/playlist/[id]/page.tsx
+++ b/src/app/playlist/[id]/page.tsx
@@ -16,6 +16,7 @@ const Playlist = async ({ params }: { params: Promise<{ id: string }> }) => {
       <PlaylistHeader
         playlistId={playlist.playlistId}
         playlistName={playlist.playlistName}
+        playlist={playlist.playlistEntries}
       />
       <div className="mx-auto flex flex-col items-center justify-center">
         {playlist.playlistEntries.map((song, index) => {
@@ -28,6 +29,7 @@ const Playlist = async ({ params }: { params: Promise<{ id: string }> }) => {
               artists={song.artists}
               playlist={playlist.playlistEntries}
               playlistId={song.playlistId}
+              trackId={song.trackId}
             />
           );
         })}


### PR DESCRIPTION
## Add shuffle functionality to music player

Implements shuffle mode for playlists with the ability to toggle on/off while preserving current playback state.  
**Follow ups:**

- dropping playllist.isShuffleOn db column
- adding shuffle icon to desktop and mobile player uis
- styling of playlist header

### Changes

- Added `skipTrackLoad` parameter to `AudioController.loadPlaylist()` to prevent automatic track loading when updating playlist order
- Extended `MusicPlayerStore` with shuffle state management:
    - Added `isShuffleOn` and `originalPlaylist` state properties
    - Enhanced `setCurrentPlaylist` with options for preserving playback state and setting track index
    - Added actions for shuffle state and original playlist management
- Created shuffle helper functions using Fisher-Yates algorithm:
    - `toggleShuffle()` for switching between shuffled and original playlist order
    - `reserveCurrentAndShuffleRest()` to keep current track first when shuffling
    - `restoreOriginalPlaylistWithCurrentPosition` restoring original playlist at current position
- Updated `PlaylistHeader` with shuffle and play buttons that respect shuffle state
- Modified `PlaylistItem` to handle shuffle mode when playing tracks, using track ID instead of index for current track detection
- Passed `trackId` prop to `PlaylistItem` components for proper track identification