### PR TITLE
shuffle in desktop and mobile players

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "previoustrack",
     "seekbackward",
     "seekforward",
+    "sidekickicons",
     "soundcloud",
     "streamable",
     "unstarted",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@clerk/nextjs": "^6.37.3",
+        "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.2.2",
         "@js-temporal/polyfill": "^0.5.1",
         "@prisma/client": "^6.5.0",
@@ -23,6 +24,7 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.3",
+        "@sidekickicons/react": "^0.15.0",
         "@t3-oss/env-nextjs": "^0.12.0",
         "@tanstack/react-query": "^5.69.0",
         "@tanstack/react-table": "^8.21.3",
@@ -896,6 +898,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
@@ -3964,6 +3975,15 @@
       "integrity": "sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sidekickicons/react": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@sidekickicons/react/-/react-0.15.0.tgz",
+      "integrity": "sha512-z59NZ/Pb58aqVDrSuvpDTscudkKU4DFrhawA05TU+zRpwJYiGP21qXgAcgPeHNm38FJm/lygw8ZVCHI7kYr0Sg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
+      }
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.37.3",
+    "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.2.2",
     "@js-temporal/polyfill": "^0.5.1",
     "@prisma/client": "^6.5.0",
@@ -42,6 +43,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@sidekickicons/react": "^0.15.0",
     "@t3-oss/env-nextjs": "^0.12.0",
     "@tanstack/react-query": "^5.69.0",
     "@tanstack/react-table": "^8.21.3",

--- a/src/app/_components/player/components/desktop/PlaybackControl.tsx
+++ b/src/app/_components/player/components/desktop/PlaybackControl.tsx
@@ -1,9 +1,18 @@
-import { Button } from "~/components/ui/button";
-import { Play, Pause, SkipForward, SkipBack } from "lucide-react";
 import {
-  useMusicPlayerStore,
+  BackwardIcon,
+  ForwardIcon,
+  PauseIcon,
+  PlayIcon,
+} from "@heroicons/react/24/solid";
+import { ArrowsCrossingIcon } from "@sidekickicons/react/24/solid";
+
+import { toggleShuffle } from "~/app/_components/player/helpers/shuffleFunctions";
+import {
   useMusicPlayerComputed,
+  useMusicPlayerStore,
 } from "~/app/_components/player/MusicPlayerStore";
+import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
 
 interface PlaybackControlProps {
   onPlay: () => void;
@@ -19,12 +28,20 @@ export const PlaybackControl = ({
   onPrevious,
 }: PlaybackControlProps) => {
   const isPlaying = useMusicPlayerStore((s) => s.isPlaying);
+  const isShuffleOn = useMusicPlayerStore((s) => s.isShuffleOn);
   const { hasNextTrack } = useMusicPlayerComputed();
 
   return (
-    <div className="flex flex-row gap-2">
-      <Button onClick={onPrevious} variant="ghost">
-        <SkipBack className="h-4 w-4" fill="#fff" />
+    <div className="flex flex-row">
+      <Button
+        onClick={toggleShuffle}
+        variant="ghost"
+        className={cn("px-2!", isShuffleOn ? "text-amber-600" : "text-primary")}
+      >
+        <ArrowsCrossingIcon />
+      </Button>
+      <Button onClick={onPrevious} variant="ghost" className="px-2!">
+        <BackwardIcon className="size-5" fill="#fff" />
       </Button>
 
       <Button
@@ -33,14 +50,19 @@ export const PlaybackControl = ({
         size="icon"
       >
         {isPlaying ? (
-          <Pause className="size-6" fill="#fff" />
+          <PauseIcon className="size-7" fill="#fff" />
         ) : (
-          <Play fill="#fff" className="size-6" />
+          <PlayIcon className="size-7" fill="#fff" />
         )}
       </Button>
 
-      <Button onClick={onNext} variant="ghost" disabled={!hasNextTrack}>
-        <SkipForward className="h-4 w-4" fill="#fff" />
+      <Button
+        onClick={onNext}
+        variant="ghost"
+        disabled={!hasNextTrack}
+        className="px-2!"
+      >
+        <ForwardIcon className="size-5" fill="#fff" />
       </Button>
     </div>
   );

--- a/src/app/_components/player/components/desktop/VolumeControl.tsx
+++ b/src/app/_components/player/components/desktop/VolumeControl.tsx
@@ -1,12 +1,12 @@
+import { SpeakerWaveIcon } from "@heroicons/react/24/solid";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 import { Button } from "~/components/ui/button";
-import { Slider } from "~/components/ui/slider";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "~/components/ui/popover";
-import { Volume2 } from "lucide-react";
-import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
+import { Slider } from "~/components/ui/slider";
 
 interface VolumeControlProps {
   onVolumeChange: (value: number[]) => void;
@@ -19,7 +19,7 @@ export const VolumeControl = ({ onVolumeChange }: VolumeControlProps) => {
     <Popover>
       <PopoverTrigger asChild>
         <Button variant="ghost" size="icon" className="-ml-1">
-          <Volume2 className="size-4.5" fill="#fff" />
+          <SpeakerWaveIcon className="size-4.5" fill="#fff" />
         </Button>
       </PopoverTrigger>
       <PopoverContent side="top" className="z-101 w-fit">

--- a/src/app/_components/player/components/mobile/PlayerSheet.tsx
+++ b/src/app/_components/player/components/mobile/PlayerSheet.tsx
@@ -1,19 +1,21 @@
-import { Drawer, DrawerContent, DrawerTitle } from "~/components/ui/drawer";
-import {
-  useMusicPlayerStore,
-  useMusicPlayerComputed,
-} from "~/app/_components/player/MusicPlayerStore";
-import { Button } from "~/components/ui/button";
-import { Play, Pause, SkipForward, SkipBack } from "lucide-react";
+import { ArrowsCrossingIcon } from "@sidekickicons/react/24/solid";
+import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
 import { ProgressBar } from "~/app/_components/player/components/desktop/ProgressBar";
+import { toggleShuffle } from "~/app/_components/player/helpers/shuffleFunctions";
 import {
-  play,
-  pause,
-  next,
-  previous,
   handleProgressChange,
   handleProgressCommit,
+  next,
+  pause,
+  play,
+  previous,
 } from "~/app/_components/player/musicPlayerActions";
+import {
+  useMusicPlayerComputed,
+  useMusicPlayerStore,
+} from "~/app/_components/player/MusicPlayerStore";
+import { Button } from "~/components/ui/button";
+import { Drawer, DrawerContent, DrawerTitle } from "~/components/ui/drawer";
 
 export const PlayerSheet = ({
   open,
@@ -23,6 +25,7 @@ export const PlayerSheet = ({
   onOpenChange: (open: boolean) => void;
 }) => {
   const isPlaying = useMusicPlayerStore((s) => s.isPlaying);
+  const isShuffleOn = useMusicPlayerStore((s) => s.isShuffleOn);
 
   const { currentTrack, hasNextTrack } = useMusicPlayerComputed();
 
@@ -33,15 +36,24 @@ export const PlayerSheet = ({
           <DrawerTitle>Player</DrawerTitle>
         </div>
         <div className="flex flex-col justify-between gap-4 px-4 py-8">
-          <div className="flex flex-col">
-            <p className="line-clamp-1 truncate font-semibold">
-              {currentTrack?.title}
-            </p>
-            <p className="text-muted-foreground line-clamp-1 truncate text-sm">
-              {currentTrack?.artists
-                .map((artist) => artist.artistName)
-                .join(", ")}
-            </p>
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col">
+              <p className="line-clamp-1 truncate font-semibold">
+                {currentTrack?.title}
+              </p>
+              <p className="text-muted-foreground line-clamp-1 truncate text-sm">
+                {currentTrack?.artists
+                  .map((artist) => artist.artistName)
+                  .join(", ")}
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              onClick={toggleShuffle}
+              className={isShuffleOn ? "text-amber-600" : "text-primary"}
+            >
+              <ArrowsCrossingIcon className="size-5" />
+            </Button>
           </div>
           <div className="align-center flex justify-between">
             <Button variant="ghost" onClick={previous}>

--- a/src/app/playlist/[id]/PlaylistHeader.tsx
+++ b/src/app/playlist/[id]/PlaylistHeader.tsx
@@ -1,5 +1,7 @@
 "use client";
-import { Pencil, Play, Shuffle, Trash2 } from "lucide-react";
+import { PlayIcon } from "@heroicons/react/24/solid";
+import { ArrowsCrossingIcon } from "@sidekickicons/react/24/solid";
+import { Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -114,14 +116,14 @@ export const PlaylistHeader = ({
         <div className="flex items-center justify-end gap-2">
           {/* TODO */}
           <Button
-            size="icon"
-            className={isShuffleOn ? "bg-amber-600" : "bg-primary"}
+            variant="ghost"
+            className={isShuffleOn ? "text-amber-600" : "text-primary"}
             onClick={toggleShuffle}
           >
-            <Shuffle />
+            <ArrowsCrossingIcon className="size-6" />
           </Button>
-          <Button size="icon" onClick={handlePlay}>
-            <Play />
+          <Button size="icon" onClick={handlePlay} variant="ghost">
+            <PlayIcon className="size-6" />
           </Button>
         </div>
       </div>


### PR DESCRIPTION
### TL;DR

Replaced Lucide React icons with Heroicons and Sidekick Icons throughout the music player interface and added shuffle functionality.

### What changed?

- Added `@heroicons/react` and `@sidekickicons/react` as new dependencies
- Replaced Lucide icons with Heroicons in playback controls:
  - `Play`/`Pause` → `PlayIcon`/`PauseIcon` 
  - `SkipForward`/`SkipBack` → `ForwardIcon`/`BackwardIcon`
  - `Volume2` → `SpeakerWaveIcon`
- Replaced `Shuffle` icon with `ArrowsCrossingIcon` from Sidekick Icons
- Added shuffle toggle button to desktop playback controls with visual state indication
- Updated mobile player sheet to include shuffle functionality
- Modified playlist header shuffle button styling to use ghost variant with conditional text coloring
- Added "sidekickicons" to VSCode spell checker dictionary

### How to test?

1. Navigate to any playlist and verify the new play and shuffle buttons work correctly
2. Open the music player and test all playback controls (play, pause, next, previous, shuffle)
3. Test the mobile player sheet by opening it on a mobile device or narrow viewport
4. Verify shuffle state is visually indicated with amber coloring when active
5. Test volume control popover functionality

### Why make this change?

This change standardizes the icon library usage and improves the visual consistency of the music player interface. The addition of shuffle functionality enhances the user experience by providing more playback control options directly in the player interface.