### PR TITLE
delete track mutation and frontend

### DIFF
--- a/src/app/_components/ConfirmationDialog.tsx
+++ b/src/app/_components/ConfirmationDialog.tsx
@@ -21,7 +21,7 @@ export const ConfirmationDialog = ({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <DialogHeader className="sm:text-center">{text}</DialogHeader>
+        <DialogHeader className="pt-3 sm:text-center">{text}</DialogHeader>
         <DialogFooter className="sm:justify-center">
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>

--- a/src/app/_components/TrackOptions.tsx
+++ b/src/app/_components/TrackOptions.tsx
@@ -4,24 +4,25 @@ import { Ellipsis } from "lucide-react";
 
 import {
   DropdownMenu,
-  DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuSub,
-  DropdownMenuSubTrigger,
   DropdownMenuSubContent,
-  DropdownMenuPortal,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu";
 
+import { useEffect, useState } from "react";
 import { EditTrack } from "./forms/EditTrack";
-import { useState, useEffect } from "react";
 
-import type { PlaylistTrack } from "./player/types/player";
-import { PlaylistSelector } from "./forms/PlaylistSelector";
-import { api } from "~/trpc/react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { api } from "~/trpc/react";
+import { ConfirmationDialog } from "./ConfirmationDialog";
+import { PlaylistSelector } from "./forms/PlaylistSelector";
+import type { PlaylistTrack } from "./player/types/player";
 
 export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
   const utils = api.useUtils();
@@ -29,6 +30,7 @@ export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
   const [open, setOpen] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [selectedPlaylists, setSelectedPlaylists] = useState<number[]>([]);
+  const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
 
   const { data: trackPlaylists } = api.tracks.getTrackPlaylists.useQuery(
     {
@@ -61,6 +63,22 @@ export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
       },
     });
 
+  const deleteTrackMutation = api.tracks.deleteTrack.useMutation({
+    onSuccess: async () => {
+      await utils.tracks.getTrackPlaylists.invalidate({
+        trackId: song.trackId,
+      });
+      await utils.playlists.getAll.invalidate();
+      await utils.playlists.getById.invalidate({ id: song.playlistId });
+      router.refresh();
+      toast.success("Song deleted");
+    },
+    onError: (error) => {
+      console.error(error);
+      toast.error("Error deleting song");
+    },
+  });
+
   useEffect(() => {
     if (trackPlaylists) {
       setSelectedPlaylists(trackPlaylists);
@@ -84,6 +102,12 @@ export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
         <DropdownMenuContent className="p-2">
           <DropdownMenuItem onClick={() => setOpen(true)}>
             edit song
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => setConfirmationDialogOpen(true)}
+            className="text-red-500 hover:text-red-500!"
+          >
+            delete song
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           {song.sourceUrl && (
@@ -118,6 +142,12 @@ export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
         </DropdownMenuContent>
       </DropdownMenu>
       {open && <EditTrack open={open} onOpenChange={setOpen} song={song} />}
+      <ConfirmationDialog
+        text="Are you sure you want to delete this song? It will be removed from your library and all playlists."
+        onConfirm={() => deleteTrackMutation.mutate({ id: song.trackId })}
+        open={confirmationDialogOpen}
+        onOpenChange={setConfirmationDialogOpen}
+      />
     </>
   );
 };

--- a/src/server/api/routers/tracks.ts
+++ b/src/server/api/routers/tracks.ts
@@ -1,6 +1,6 @@
+import { type Album, type SongSource } from "@prisma/client";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
-import { type Album, type SongSource } from "@prisma/client";
 
 export const tracksRouter = createTRPCRouter({
   addTrack: protectedProcedure
@@ -221,5 +221,15 @@ export const tracksRouter = createTRPCRouter({
       return playlistEntries.map((entry) => {
         return entry.playlistId;
       });
+    }),
+  // TODO: will leave a gap in playlist positions
+  // the original track will also remain,
+  deleteTrack: protectedProcedure
+    .input(z.object({ id: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db.libraryTrack.delete({
+        where: { id: input.id, userId: ctx.user.id },
+      });
+      return { success: true };
     }),
 });


### PR DESCRIPTION
### TL;DR

Added delete functionality for tracks with confirmation dialog and improved dialog header spacing

### What changed?

- Added a "delete song" option to the TrackOptions dropdown menu with red styling
- Implemented `deleteTrack` mutation in the tracks router that removes tracks from user's library
- Added ConfirmationDialog component to TrackOptions for delete confirmation

### How to test?

1. Navigate to any track in a playlist
2. Click the three-dot menu (TrackOptions)
3. Click "delete song" - should show red text
4. Confirm the deletion in the dialog that appears
5. Verify the track is removed from the playlist and library
6. Check that the confirmation dialog header has proper spacing

### Why make this change?

Users need the ability to remove unwanted tracks from their library. The confirmation dialog prevents accidental deletions, and the visual styling (red text) clearly indicates this is a destructive action. The header padding improvement enhances the overall user experience of confirmation dialogs.