### PR TITLE
better media session authority

### DIFF
--- a/src/app/_components/player/adapters/SoundCloudAdapter.ts
+++ b/src/app/_components/player/adapters/SoundCloudAdapter.ts
@@ -2,6 +2,7 @@
 
 import { useMusicPlayerStore } from "../MusicPlayerStore";
 import type { MusicPlayerAdapter, SoundCloudSound } from "../types/player";
+import { startAnchorAndUpdateMediaSession } from "../utils";
 
 declare global {
   interface Window {
@@ -113,6 +114,7 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
 
         this.player.bind(window.SC.Widget.Events.PLAY, () => {
           useMusicPlayerStore.getState().setIsPlaying(true);
+          void startAnchorAndUpdateMediaSession();
         });
 
         this.player.bind(window.SC.Widget.Events.FINISH, () => {

--- a/src/app/_components/player/adapters/SpotifyAdapter.ts
+++ b/src/app/_components/player/adapters/SpotifyAdapter.ts
@@ -3,6 +3,7 @@
 import { getOrRefreshSpotifyToken } from "~/lib/actions/getOrRefreshSpotifyToken";
 import { useMusicPlayerStore } from "../MusicPlayerStore";
 import type { MusicPlayerAdapter } from "../types/player";
+import { startAnchorAndUpdateMediaSession } from "../utils";
 
 declare global {
   interface Window {
@@ -119,6 +120,7 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
           async ({ paused, loading }) => {
             if (!paused && !loading) {
               useMusicPlayerStore.getState().setIsPlaying(true);
+              void startAnchorAndUpdateMediaSession();
             }
           },
         );
@@ -211,7 +213,6 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
     }
 
     await this.player.resume();
-    useMusicPlayerStore.getState().setIsPlaying(true);
   }
 
   async pause(): Promise<void> {

--- a/src/app/_components/player/adapters/YouTubeAdapter.ts
+++ b/src/app/_components/player/adapters/YouTubeAdapter.ts
@@ -2,6 +2,7 @@
 
 import { useMusicPlayerStore } from "../MusicPlayerStore";
 import type { MusicPlayerAdapter } from "../types/player";
+import { startAnchorAndUpdateMediaSession } from "../utils";
 
 declare global {
   interface Window {
@@ -104,6 +105,7 @@ export class YouTubeAdapter implements MusicPlayerAdapter {
           onStateChange: (event) => {
             if (event.data === 1) {
               useMusicPlayerStore.getState().setIsPlaying(true);
+              void startAnchorAndUpdateMediaSession();
             }
           },
         },

--- a/src/app/_components/player/components/MediaSessionAnchor.tsx
+++ b/src/app/_components/player/components/MediaSessionAnchor.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect } from "react";
-import { loadPlayerScripts } from "~/app/_components/player/utils";
-import { startProgressTimer } from "~/app/_components/player/progressTimer";
 import { setupMediaSession } from "~/app/_components/player/musicPlayerActions";
+import { startProgressTimer } from "~/app/_components/player/progressTimer";
+import { loadPlayerScripts } from "~/app/_components/player/utils";
 
 export const AppMediaAnchor = () => {
   useEffect(() => {

--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -1,14 +1,12 @@
 import { AudioController } from "./AudioController";
 import { useMusicPlayerStore } from "./MusicPlayerStore";
-import {
-  pauseAnchorAudio,
-  scheduleAnchorAndMediaSession,
-  setMediaSessionMetadata,
-} from "./utils";
+import { pauseAnchorAudio, setMediaSessionMetadata } from "./utils";
 
 export const setupMediaSession = (metadata: MediaMetadataInit | null): void => {
-  if (typeof navigator === "undefined" || !("mediaSession" in navigator))
+  if (typeof navigator === "undefined" || !("mediaSession" in navigator)) {
+    console.warn("Media session not in navigator");
     return;
+  }
 
   navigator.mediaSession.setActionHandler("play", () => {
     void play();
@@ -41,7 +39,7 @@ export const pause = async (): Promise<void> => {
   if (controller && isLoaded) {
     await controller.pause();
     setIsPlaying(false);
-    pauseAnchorAudio();
+    navigator.mediaSession.playbackState = "paused";
   }
 };
 
@@ -81,8 +79,6 @@ export const previous = async (): Promise<void> => {
       await controller.previousTrack();
       await controller.setVolume(volume);
       setDuration(controller.duration);
-
-      scheduleAnchorAndMediaSession();
     }
   }
 };
@@ -116,8 +112,6 @@ export const next = async (): Promise<void> => {
     await controller.nextTrack();
     await controller.setVolume(volume);
     setDuration(controller.duration);
-
-    scheduleAnchorAndMediaSession();
   }
 };
 
@@ -158,7 +152,6 @@ export const play = async (): Promise<void> => {
     try {
       await controller.play();
       await controller.setVolume(volume);
-      scheduleAnchorAndMediaSession();
     } catch {
       setIsPlaying(false);
     }

--- a/src/app/_components/player/utils.ts
+++ b/src/app/_components/player/utils.ts
@@ -82,19 +82,39 @@ export const pauseAnchorAudio = (): void => {
   }
 };
 
-// TODO: find a better way to regain media session control, still too brittle
-// see if events can be relied on or listening for audio starting with js maybe
-export const scheduleAnchorAndMediaSession = (): void => {
-  setTimeout(() => {
-    void startAnchorAudio();
+const ANCHOR_SESSION_DELAY_MS = 500;
+let anchorSessionUpdateInProgress = false;
+/**
+ * Start anchor audio and update Media Session after a short delay so the main
+ * player (iframe/SDK) can settle and we don't race for the session. Guard
+ * prevents overlapping runs when adapters fire "playback started" multiple times.
+ */
+export const startAnchorAndUpdateMediaSession = async (): Promise<void> => {
+  if (anchorSessionUpdateInProgress) return;
+  anchorSessionUpdateInProgress = true;
+  try {
+    /* needed to do this because when hitting 'pause' we don't actually pause the 
+    anchor to retain media session control. When restarting playback, 
+    have to pause the anchor or else the start call doesn't take control */
+    pauseAnchorAudio();
+
+    await new Promise((r) => setTimeout(r, ANCHOR_SESSION_DELAY_MS));
+    await startAnchorAudio();
     const controller = useMusicPlayerStore.getState().controller;
     const metadata = controller?.getMediaMetadata() ?? null;
     setMediaSessionMetadata(metadata);
-  }, 1500);
+  } catch (e) {
+    console.warn("Failed to start anchor / media session", e);
+  } finally {
+    anchorSessionUpdateInProgress = false;
+  }
 };
 
 export const setMediaSessionMetadata = (metadata: MediaMetadataInit | null) => {
-  if (!("mediaSession" in navigator)) return;
+  if (!("mediaSession" in navigator)) {
+    console.warn("Media session not in navigator");
+    return;
+  }
   if (metadata) {
     navigator.mediaSession.metadata = new MediaMetadata(metadata);
   }


### PR DESCRIPTION
### TL;DR

Refactored media session control to use a centralized function that prevents race conditions and overlapping updates when playback starts.

### What changed?

- Added `startAnchorAndUpdateMediaSession()` function with guard logic to prevent overlapping execution
- Integrated this function into all three player adapters (SoundCloud, Spotify, YouTube) on play events
- Removed  `scheduleAnchorAndMediaSession()` calls from previous/next track operations, only called when the source adapter says playback has started.
- Retained a slight delay, it seems like soundcloud and spotify can work, but youtube is flaky on its event firing.  
- Removed duplicate `setIsPlaying(true)` call from Spotify adapter's resume method

### How to test?

1. Test playback across all three platforms (SoundCloud, Spotify, YouTube)
2. Verify media session controls work properly in browser media notifications
3. Test rapid play/pause operations to ensure no race conditions occur
4. Test track navigation (previous/next) functionality
5. Check browser console for any media session warnings

### Why make this change?

The previous implementation was brittle and prone to race conditions when multiple play events fired simultaneously. The new centralized approach with guard logic is less brittle, while also improving error handling and reducing unnecessary delays.