### PR TITLE
misc mini changes

### DIFF
--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -1,6 +1,6 @@
 import { SoundCloudAdapter } from "./adapters/SoundCloudAdapter";
-import { YouTubeAdapter } from "./adapters/YouTubeAdapter";
 import { SpotifyAdapter } from "./adapters/SpotifyAdapter";
+import { YouTubeAdapter } from "./adapters/YouTubeAdapter";
 import type {
   MusicPlayerAdapter,
   PlaylistTrack,
@@ -233,5 +233,13 @@ export class AudioController {
           ]
         : [],
     };
+  }
+
+  async activateElement() {
+    if (!this.currentAdapter) {
+      console.warn("no adapter, activateElement");
+      return;
+    }
+    await this.currentAdapter.activateElement?.();
   }
 }

--- a/src/app/_components/player/adapters/SpotifyAdapter.ts
+++ b/src/app/_components/player/adapters/SpotifyAdapter.ts
@@ -35,6 +35,7 @@ interface SpotifyWidget {
   ): void;
   removeListener: (eventname: string) => void;
   on: (event: string, callback: (data: { message: string }) => void) => void;
+  activateElement: () => Promise<void>;
 }
 
 interface SpotifyPlayerState {
@@ -269,6 +270,14 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
     }
     // spotify doesn't make it available here and not worth a call
     return 0;
+  }
+
+  async activateElement(): Promise<void> {
+    if (!this.player || !this.isReady) {
+      console.warn("Spotify player not ready for activateElement");
+      return;
+    }
+    await this.player.activateElement();
   }
 
   readonly sound: null = null;

--- a/src/app/_components/player/types/player.ts
+++ b/src/app/_components/player/types/player.ts
@@ -8,6 +8,7 @@ export interface MusicPlayerAdapter {
   getCurrentTime(): Promise<number>;
   seekTo(seconds: number): void | Promise<void>;
   setVolume(value: number): void | Promise<void>;
+  activateElement?(): Promise<void>;
   readonly duration: number;
   readonly sound: SoundCloudSound | null;
 }

--- a/src/app/playlist/[id]/PlaylistItem.tsx
+++ b/src/app/playlist/[id]/PlaylistItem.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import Lottie from "lottie-react";
 import { Play } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { reserveCurrentAndShuffleRest } from "~/app/_components/player/helpers/shuffleFunctions";
+import { play } from "~/app/_components/player/musicPlayerActions";
 import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 import type { PlaylistTrack } from "~/app/_components/player/types/player";
 import { TrackOptions } from "~/app/_components/TrackOptions";
-import Lottie from "lottie-react";
 import SoundWave from "./SoundWave.json";
-import Link from "next/link";
-import { useShallow } from "zustand/react/shallow";
-import { play } from "~/app/_components/player/musicPlayerActions";
-import { reserveCurrentAndShuffleRest } from "~/app/_components/player/helpers/shuffleFunctions";
 
 interface PlaylistItemProps {
   index: number;

--- a/src/app/playlists/page.tsx
+++ b/src/app/playlists/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { api } from "~/trpc/react";
 import Link from "next/link";
 import { Spinner } from "~/components/ui/spinner";
+import { api } from "~/trpc/react";
 
 const Playlists = () => {
   const { data: playlists, isLoading } = api.playlists.getAll.useQuery();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,7 @@ export default clerkMiddleware(async (auth, req) => {
 export const config = {
   matcher: [
     // Skip Next.js internals and all static files, unless found in search params
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|mp3)).*)",
     // Always run for API routes
     "/(api|trpc)(.*)",
   ],


### PR DESCRIPTION
### TL;DR

Added `activateElement` method to audio player adapters to enable programmatic activation of media elements

### What changed?

- Added optional `activateElement()` method to the `MusicPlayerAdapter` interface
- Implemented `activateElement()` in `SpotifyAdapter` that calls the Spotify widget's activation method
- Added `activateElement()` method to `AudioController` that delegates to the current adapter
- Reordered import statements in several components for consistency
- Updated middleware configuration to exclude `.mp3` files from processing

### How to test?

1. Load a Spotify track in the player
2. Call the `activateElement()` method on the audio controller
3. Verify that the Spotify player element becomes active and ready for interaction
4. Test that the method handles cases where no adapter is available or the player isn't ready

### Why make this change?

This change enables programmatic activation of media player elements, which is particularly important for Spotify's embedded player that requires explicit activation before it can be controlled. The optional interface design allows other adapters to implement this functionality as needed while maintaining backward compatibility.