### PR TITLE
media session improvements

### DIFF
--- a/src/app/_components/player/adapters/YouTubeAdapter.ts
+++ b/src/app/_components/player/adapters/YouTubeAdapter.ts
@@ -90,7 +90,7 @@ export class YouTubeAdapter implements MusicPlayerAdapter {
   }
 
   private async initializeWidget(trackUrl: string): Promise<void> {
-    // fresh iframe each load so mobile suspended/broken reuse state.
+    // fresh iframe each load to ignore mobile suspended/broken reuse state.
     this.removeExistingPlayer();
 
     const iframe = this.getOrCreateIframe();
@@ -113,7 +113,6 @@ export class YouTubeAdapter implements MusicPlayerAdapter {
           onStateChange: (event) => {
             if (event.data === 1) {
               useMusicPlayerStore.getState().setIsPlaying(true);
-              this.player!.playVideo();
               void startAnchorAndUpdateMediaSession();
             }
           },

--- a/src/app/_components/player/components/MediaSessionAnchor.tsx
+++ b/src/app/_components/player/components/MediaSessionAnchor.tsx
@@ -16,7 +16,7 @@ export const AppMediaAnchor = () => {
   }, []);
 
   useEffect(() => {
-    setupMediaSession(null);
+    setupMediaSession();
   }, []);
 
   return (

--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -1,36 +1,57 @@
 import { AudioController } from "./AudioController";
 import { useMusicPlayerStore } from "./MusicPlayerStore";
-import { pauseAnchorAudio, setMediaSessionMetadata } from "./utils";
+import {
+  pauseAnchorAudio,
+  setMediaSessionMetadata,
+  startAnchorAndUpdateMediaSession,
+} from "./utils";
 
-export const setupMediaSession = (metadata: MediaMetadataInit | null): void => {
+export const setupMediaSession = (): void => {
   if (typeof navigator === "undefined" || !("mediaSession" in navigator)) {
     console.warn("Media session not in navigator");
     return;
   }
 
-  navigator.mediaSession.setActionHandler("play", () => {
-    void play();
+  /*
+   * ts has the return for this as void, but according to mdn docs it can be async
+   * https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/setActionHandler#examples
+   */
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  navigator.mediaSession.setActionHandler("play", async () => {
+    await play();
+    await startAnchorAndUpdateMediaSession();
   });
-  navigator.mediaSession.setActionHandler("pause", () => {
-    void pause();
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  navigator.mediaSession.setActionHandler("pause", async () => {
+    await pause();
+    setMediaSessionMetadata();
+    /* 
+    tend to lose the metadata when pausing even with this
+    playing or next/prev regains
+    at least on mobile 
+    */
   });
-  navigator.mediaSession.setActionHandler("nexttrack", () => {
-    void next();
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  navigator.mediaSession.setActionHandler("nexttrack", async () => {
+    await next();
+    await startAnchorAndUpdateMediaSession();
   });
-  navigator.mediaSession.setActionHandler("previoustrack", () => {
-    void previous();
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  navigator.mediaSession.setActionHandler("previoustrack", async () => {
+    await previous();
+    await startAnchorAndUpdateMediaSession();
   });
   // iOS shows 10s seek buttons; map them to next/previous track
-  navigator.mediaSession.setActionHandler("seekforward", () => {
-    void next();
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  navigator.mediaSession.setActionHandler("seekforward", async () => {
+    await next();
+    await startAnchorAndUpdateMediaSession();
   });
-  navigator.mediaSession.setActionHandler("seekbackward", () => {
-    void previous();
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  navigator.mediaSession.setActionHandler("seekbackward", async () => {
+    await previous();
+    await startAnchorAndUpdateMediaSession();
   });
-
-  if (metadata) {
-    setMediaSessionMetadata(metadata);
-  }
 };
 
 export const pause = async (): Promise<void> => {

--- a/src/app/_components/player/utils.ts
+++ b/src/app/_components/player/utils.ts
@@ -82,7 +82,17 @@ export const pauseAnchorAudio = (): void => {
   }
 };
 
-const ANCHOR_SESSION_DELAY_MS = 500;
+export const setMediaSessionMetadata = () => {
+  if (!("mediaSession" in navigator)) {
+    console.warn("Media session not in navigator");
+    return;
+  }
+  const controller = useMusicPlayerStore.getState().controller;
+  const metadata = controller?.getMediaMetadata() ?? undefined;
+  navigator.mediaSession.metadata = new MediaMetadata(metadata);
+};
+
+const ANCHOR_SESSION_DELAY_MS = 600;
 let anchorSessionUpdateInProgress = false;
 /**
  * Start anchor audio and update Media Session after a short delay so the main
@@ -100,22 +110,10 @@ export const startAnchorAndUpdateMediaSession = async (): Promise<void> => {
 
     await new Promise((r) => setTimeout(r, ANCHOR_SESSION_DELAY_MS));
     await startAnchorAudio();
-    const controller = useMusicPlayerStore.getState().controller;
-    const metadata = controller?.getMediaMetadata() ?? null;
-    setMediaSessionMetadata(metadata);
+    setMediaSessionMetadata();
   } catch (e) {
     console.warn("Failed to start anchor / media session", e);
   } finally {
     anchorSessionUpdateInProgress = false;
-  }
-};
-
-export const setMediaSessionMetadata = (metadata: MediaMetadataInit | null) => {
-  if (!("mediaSession" in navigator)) {
-    console.warn("Media session not in navigator");
-    return;
-  }
-  if (metadata) {
-    navigator.mediaSession.metadata = new MediaMetadata(metadata);
   }
 };


### PR DESCRIPTION
### TL;DR

Making the setActionHandler's async makes media session control a lot more reliable on mobile. 

### What changed?

- Removed redundant `playVideo()` call in YouTube adapter's state change handler that was causing double play events
- Updated media session action handlers to use proper async/await patterns instead of void promises
- Refactored `setMediaSessionMetadata` to handle undefined metadata gracefully and moved it to utils
- Modified `setupMediaSession` to no longer accept metadata parameter since it now calls the metadata function directly
- Added metadata refresh on pause action to help maintain media session info on mobile

### How to test?

1. Play a YouTube track and verify it doesn't start playing twice
2. Test media session controls (play/pause/next/previous) on mobile and desktop
3. Verify media session metadata displays correctly and persists during playback controls
4. Test seek forward/backward buttons on iOS to ensure they trigger next/previous track

### Why make this change?

The redundant `playVideo()` call was causing tracks to restart or play twice when the YouTube player state changed to playing. The media session handlers needed proper async handling to ensure metadata updates occur after playback state changes complete, improving the user experience with system media controls.