### PR TITLE
change how next and prev work

### DIFF
--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -26,9 +26,8 @@ export const setupMediaSession = (): void => {
     await pause();
     setMediaSessionMetadata();
     /* 
-    tend to lose the metadata when pausing even with this
-    playing or next/prev regains
-    at least on mobile 
+    tend to lose the metadata when pausing even with this.
+    playing or next/prev regains at least on mobile 
     */
   });
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -66,7 +65,6 @@ export const pause = async (): Promise<void> => {
 
 export const previous = async (): Promise<void> => {
   const {
-    volume,
     currentPlaylist,
     controller,
     currentTime,
@@ -74,7 +72,6 @@ export const previous = async (): Promise<void> => {
     setCurrentTime,
     setCurrentTrackIndex,
     setDuration,
-    setIsPlaying,
   } = useMusicPlayerStore.getState();
 
   const hasPreviousTrack = currentTrackIndex > 0;
@@ -89,31 +86,24 @@ export const previous = async (): Promise<void> => {
     }
 
     if (hasPreviousTrack) {
-      pauseAnchorAudio();
-
       setCurrentTrackIndex(currentTrackIndex - 1);
 
       setCurrentTime(0.01);
       setDuration(0.9);
-      await controller.pause();
-      setIsPlaying(false);
-      await controller.previousTrack();
-      await controller.setVolume(volume);
-      setDuration(controller.duration);
+
+      await play();
     }
   }
 };
 
 export const next = async (): Promise<void> => {
   const {
-    volume,
     currentPlaylist,
     controller,
     currentTrackIndex,
     setCurrentTime,
     setCurrentTrackIndex,
     setDuration,
-    setIsPlaying,
   } = useMusicPlayerStore.getState();
 
   const hasNextTrack = currentPlaylist
@@ -121,18 +111,13 @@ export const next = async (): Promise<void> => {
     : false;
 
   if (currentPlaylist && hasNextTrack && controller) {
-    pauseAnchorAudio();
     setCurrentTrackIndex(currentTrackIndex + 1);
 
     // hacky loading state to get the slider and duration to properly display while loading next track
     setCurrentTime(0.01);
     setDuration(0.9);
 
-    await controller.pause();
-    setIsPlaying(false);
-    await controller.nextTrack();
-    await controller.setVolume(volume);
-    setDuration(controller.duration);
+    await play();
   }
 };
 


### PR DESCRIPTION
### TL;DR

Simplified track navigation by removing redundant pause/play logic and letting the `play()` function handle playback state

### What changed?

- Removed unused imports (`volume`, `setIsPlaying`) from `previous()` and `next()` functions
- Replaced manual pause/play sequence with a single `play()` call in both navigation functions
- Removed `pauseAnchorAudio()`, `controller.pause()`, `controller.nextTrack()`, `controller.previousTrack()`, and volume setting calls
- Updated comment formatting in the media session setup

### How to test?

1. Load a playlist with multiple tracks
2. Test previous track navigation using media controls or UI buttons
3. Test next track navigation using media controls or UI buttons
4. Verify tracks play automatically after navigation
5. Test on both desktop and mobile devices to ensure media session controls work properly

### Why make this change?

The previous implementation had redundant logic where tracks were manually paused, navigated, and then required separate play actions. By delegating to the existing `play()` function, the code is cleaner and ensures consistent playback behavior across all navigation scenarios.