### PR TITLE
sc adapted teardown iframe each time

### DIFF
--- a/src/app/_components/player/adapters/SoundCloudAdapter.ts
+++ b/src/app/_components/player/adapters/SoundCloudAdapter.ts
@@ -43,7 +43,6 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
   private player: SoundCloudWidget | null = null;
   private iframeId: string;
   private isReady: boolean = false;
-  private isInitialized: boolean = false;
   private currentSound: SoundCloudSound | null = null;
 
   constructor(iframeId: string = "soundcloud-player") {
@@ -53,13 +52,7 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
   async loadTrack(trackUrl: string): Promise<void> {
     this.isReady = false;
 
-    if (!this.isInitialized) {
-      // First time, create the widget
-      await this.initializeWidget(trackUrl);
-    } else {
-      // Subsequent loads
-      await this.loadNewTrack(trackUrl);
-    }
+    await this.initializeWidget(trackUrl);
   }
 
   private async waitForValidSound(): Promise<SoundCloudSound> {
@@ -78,6 +71,8 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
   }
 
   private async initializeWidget(trackUrl: string): Promise<void> {
+    this.removeExistingPlayer();
+
     const iframe = this.getOrCreateIframe();
     const encodedUrl = encodeURIComponent(trackUrl);
     const scUrl = `https://w.soundcloud.com/player/?url=${encodedUrl}`;
@@ -91,6 +86,7 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
 
         if (!this.player) {
           console.warn("SoundCloud widget not found");
+          resolve();
           return;
         }
 
@@ -99,7 +95,6 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
             .then((sound) => {
               this.currentSound = sound;
               this.isReady = true;
-              this.isInitialized = true;
               resolve();
             })
             .catch((error) => {
@@ -129,6 +124,9 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
     });
   }
 
+  /*
+  deprecated, tear down iframe each time now.
+
   private async loadNewTrack(trackUrl: string): Promise<void> {
     this.isReady = false;
     if (!this.player) {
@@ -154,6 +152,7 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
       });
     });
   }
+  */
 
   play(): void {
     if (!this.player || !this.isReady) {
@@ -252,5 +251,11 @@ export class SoundCloudAdapter implements MusicPlayerAdapter {
     }
 
     return iframe;
+  }
+
+  private removeExistingPlayer(): void {
+    document.getElementById(this.iframeId)?.remove();
+    this.player = null;
+    this.currentSound = null;
   }
 }


### PR DESCRIPTION
### TL;DR

SoundCloudAdapter, removing track reuse logic and always recreating the iframe widget for each track load. makes it more reliable on mobile

### What changed?

- Removed `isInitialized` flag and related conditional logic
- Eliminated the `loadNewTrack()` method (now commented as deprecated)
- Modified `loadTrack()` to always call `initializeWidget()`
- Added `removeExistingPlayer()` method that cleans up the existing iframe, player, and sound references
- Updated `initializeWidget()` to call `removeExistingPlayer()` before creating a new widget
- Added missing `resolve()` call when SoundCloud widget is not found

### How to test?

1. Load a SoundCloud track in the player
2. Load a different SoundCloud track
3. Verify that the new track loads correctly and the previous iframe is properly removed from the DOM
4. Test multiple consecutive track loads to ensure no memory leaks or stale references

### Why make this change?

This change simplifies the adapter logic by removing the complexity of trying to reuse existing SoundCloud widgets. Instead of maintaining state to determine whether to initialize or reload, the adapter now consistently tears down and recreates the iframe for each track, which should be more reliable and easier to maintain.