### PR TITLE
spotify autoplay on mobile fixes

### DIFF
--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -1,6 +1,7 @@
 import { SoundCloudAdapter } from "./adapters/SoundCloudAdapter";
 import { SpotifyAdapter } from "./adapters/SpotifyAdapter";
 import { YouTubeAdapter } from "./adapters/YouTubeAdapter";
+import { useMusicPlayerStore } from "./MusicPlayerStore";
 import type {
   MusicPlayerAdapter,
   PlaylistTrack,
@@ -32,7 +33,14 @@ export class AudioController {
         adapter = new YouTubeAdapter();
         break;
       case "spotify":
-        adapter = new SpotifyAdapter();
+        const preInitializedAdapter =
+          useMusicPlayerStore.getState().preInitializedSpotifyAdapter;
+
+        if (preInitializedAdapter) {
+          adapter = preInitializedAdapter;
+        } else {
+          adapter = new SpotifyAdapter();
+        }
         break;
       default:
         console.error(`Unsupported track source: ${source}`);

--- a/src/app/_components/player/MusicPlayerStore.ts
+++ b/src/app/_components/player/MusicPlayerStore.ts
@@ -1,7 +1,8 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
-import type { PlaylistTrack } from "./types/player";
 import type { AudioController } from "./AudioController";
+import type { SpotifyAdapter } from "./adapters/SpotifyAdapter";
+import type { PlaylistTrack } from "./types/player";
 
 type setPlaylistOptions = {
   preservePlaybackState?: boolean;
@@ -27,6 +28,7 @@ interface MusicPlayerState {
 
   // controller
   controller: AudioController | null;
+  preInitializedSpotifyAdapter: SpotifyAdapter | null;
 
   // actions
   setCurrentPlaylist: (
@@ -45,6 +47,7 @@ interface MusicPlayerState {
   setIsSeeking: (isSeeking: boolean) => void;
   setLoadedOnce: (loadedOnce: boolean) => void;
   setController: (controller: AudioController) => void;
+  setPreInitializedSpotifyAdapter: (adapter: SpotifyAdapter) => void;
 }
 
 export const useMusicPlayerStore = create<MusicPlayerState>()(
@@ -62,6 +65,8 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
       currentTime: 0,
       isSeeking: false,
       loadedOnce: false,
+      controller: null,
+      preInitializedSpotifyAdapter: null,
 
       setCurrentPlaylist: (
         playlist: PlaylistTrack[],
@@ -100,6 +105,8 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
       setIsSeeking: (seeking: boolean) => set({ isSeeking: seeking }),
       setLoadedOnce: (loadedOnce: boolean) => set({ loadedOnce: loadedOnce }),
       setController: (controller: AudioController) => set({ controller }),
+      setPreInitializedSpotifyAdapter: (adapter: SpotifyAdapter) =>
+        set({ preInitializedSpotifyAdapter: adapter }),
     }),
     {
       name: "music-player-store",

--- a/src/app/_components/player/adapters/SpotifyAdapter.ts
+++ b/src/app/_components/player/adapters/SpotifyAdapter.ts
@@ -94,9 +94,14 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
   private isInitialized: boolean = false;
   private deviceId: string | null = null;
 
-  private async initializeWidget(trackId: string): Promise<void> {
+  async initializeWidget(trackId?: string): Promise<void> {
     return new Promise((resolve) => {
       const setupPlayer = () => {
+        if (this.isInitialized) {
+          resolve();
+          return;
+        }
+
         const player = new window.Spotify.Player({
           name: "Aggregate",
           getOAuthToken: async (cb) => {
@@ -112,7 +117,9 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
           this.deviceId = device_id;
           this.isInitialized = true;
           this.isReady = true;
-          await this.loadNewTrack(trackId);
+          if (trackId) {
+            await this.loadNewTrack(trackId);
+          }
           resolve();
         });
 
@@ -139,7 +146,8 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
         });
 
         player.on("playback_error", ({ message }) => {
-          console.error("Spotify failed to connect", message);
+          // sometimes fires on first play, race condition, not really a problem
+          console.warn("Spotify failed to connect", message);
         });
 
         player.on("autoplay_failed", () => {

--- a/src/app/_components/player/components/MediaSessionAnchor.tsx
+++ b/src/app/_components/player/components/MediaSessionAnchor.tsx
@@ -4,8 +4,13 @@ import { useEffect } from "react";
 import { setupMediaSession } from "~/app/_components/player/musicPlayerActions";
 import { startProgressTimer } from "~/app/_components/player/progressTimer";
 import { loadPlayerScripts } from "~/app/_components/player/utils";
+import { api } from "~/trpc/react";
+import { useMusicPlayerStore } from "../MusicPlayerStore";
+import { SpotifyAdapter } from "../adapters/SpotifyAdapter";
 
 export const AppMediaAnchor = () => {
+  const { data: spotifyAuth } = api.user.userConnectedToSpotify.useQuery();
+
   useEffect(() => {
     const cleanup = loadPlayerScripts();
     return cleanup;
@@ -18,6 +23,23 @@ export const AppMediaAnchor = () => {
   useEffect(() => {
     setupMediaSession();
   }, []);
+
+  useEffect(() => {
+    if (!spotifyAuth) return;
+    const existingAdapter =
+      useMusicPlayerStore.getState().preInitializedSpotifyAdapter;
+    if (existingAdapter) return;
+
+    const adapter = new SpotifyAdapter();
+    adapter
+      .initializeWidget()
+      .then(() => {
+        useMusicPlayerStore.getState().setPreInitializedSpotifyAdapter(adapter);
+      })
+      .catch((error) => {
+        console.error("Failed to initialize Spotify adapter", error);
+      });
+  }, [spotifyAuth]);
 
   return (
     <>

--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -148,6 +148,17 @@ export const play = async (): Promise<void> => {
     return;
   }
 
+  // https://developer.spotify.com/documentation/web-playback-sdk/reference#spotifyplayeractivateelement
+  if (currentTrack.source === "spotify") {
+    const { controller, preInitializedSpotifyAdapter } =
+      useMusicPlayerStore.getState();
+    if (controller) {
+      await controller.activateElement?.();
+    } else {
+      await preInitializedSpotifyAdapter?.activateElement?.();
+    }
+  }
+
   const loadTrack = async (controller: AudioController) => {
     await controller.loadPlaylist(currentPlaylist, currentTrackIndex);
     setIsLoaded(true);


### PR DESCRIPTION
### TL;DR

Pre-initialize Spotify adapter on app load to drop the autoplay failure on first play for mobile use case. 

### What changed?

- Added `preInitializedSpotifyAdapter` state to the music player store with getter/setter methods
- Modified `AudioController` to use the pre-initialized Spotify adapter when available, falling back to creating a new instance
- Updated `SpotifyAdapter.initializeWidget()` to be public and accept optional `trackId` parameter, with early return if already initialized
- Added logic in `MediaSessionAnchor` to pre-initialize Spotify adapter when user is authenticated
- Enhanced play action to activate Spotify element before loading tracks
- Changed Spotify playback error logging from error to warning level

### How to test?

1. Ensure you have Spotify authentication set up
2. Load the app and verify the Spotify adapter initializes in the background
3. Play a Spotify track and confirm it starts without the usual initialization delay
4. Test that non-Spotify tracks still work normally
5. Verify that multiple Spotify adapter instances aren't created unnecessarily

### Why make this change?

Spotify's Web Playback SDK requires initialization time that creates noticeable delays when users first play Spotify tracks. By pre-initializing the adapter when the app loads (for authenticated users), we eliminate this delay and provide a smoother playback experience.