### PR TITLE
more spotify fixes

### DIFF
--- a/src/app/_components/player/AudioController.tsx
+++ b/src/app/_components/player/AudioController.tsx
@@ -38,6 +38,7 @@ export class AudioController {
 
         if (preInitializedAdapter) {
           adapter = preInitializedAdapter;
+          useMusicPlayerStore.getState().setPreInitializedSpotifyAdapter(null);
         } else {
           adapter = new SpotifyAdapter();
         }

--- a/src/app/_components/player/MusicPlayerStore.ts
+++ b/src/app/_components/player/MusicPlayerStore.ts
@@ -47,7 +47,7 @@ interface MusicPlayerState {
   setIsSeeking: (isSeeking: boolean) => void;
   setLoadedOnce: (loadedOnce: boolean) => void;
   setController: (controller: AudioController) => void;
-  setPreInitializedSpotifyAdapter: (adapter: SpotifyAdapter) => void;
+  setPreInitializedSpotifyAdapter: (adapter: SpotifyAdapter | null) => void;
 }
 
 export const useMusicPlayerStore = create<MusicPlayerState>()(

--- a/src/app/_components/player/components/MediaSessionAnchor.tsx
+++ b/src/app/_components/player/components/MediaSessionAnchor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAuth } from "@clerk/nextjs";
 import { useEffect } from "react";
 import { setupMediaSession } from "~/app/_components/player/musicPlayerActions";
 import { startProgressTimer } from "~/app/_components/player/progressTimer";
@@ -9,7 +10,11 @@ import { useMusicPlayerStore } from "../MusicPlayerStore";
 import { SpotifyAdapter } from "../adapters/SpotifyAdapter";
 
 export const AppMediaAnchor = () => {
-  const { data: spotifyAuth } = api.user.userConnectedToSpotify.useQuery();
+  const { isSignedIn, isLoaded } = useAuth();
+  const { data: spotifyAuth } = api.user.userConnectedToSpotify.useQuery(
+    undefined,
+    { enabled: isSignedIn && isLoaded },
+  );
 
   useEffect(() => {
     const cleanup = loadPlayerScripts();

--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -150,13 +150,11 @@ export const play = async (): Promise<void> => {
 
   // https://developer.spotify.com/documentation/web-playback-sdk/reference#spotifyplayeractivateelement
   if (currentTrack.source === "spotify") {
-    const { controller, preInitializedSpotifyAdapter } =
-      useMusicPlayerStore.getState();
-    if (controller) {
-      await controller.activateElement?.();
-    } else {
-      await preInitializedSpotifyAdapter?.activateElement?.();
-    }
+    const preInitializedSpotifyAdapter =
+      useMusicPlayerStore.getState().preInitializedSpotifyAdapter;
+
+    if (preInitializedSpotifyAdapter)
+      await preInitializedSpotifyAdapter.activateElement();
   }
 
   const loadTrack = async (controller: AudioController) => {


### PR DESCRIPTION
### TL;DR

Fixed Spotify adapter lifecycle management and added authentication guards to prevent unnecessary API calls.

### What changed?

- Added null clearing of pre-initialized Spotify adapter after use in AudioController
- Updated type signature to allow null values for `setPreInitializedSpotifyAdapter`
- Added authentication checks before querying Spotify connection status
- Simplified Spotify element activation logic to only use pre-initialized adapter

### How to test?

1. Sign in and connect a Spotify account
2. Play a Spotify track and verify the adapter is properly cleaned up after initialization
3. Sign out and verify no unnecessary API calls are made to check Spotify connection
4. Test Spotify playback activation works correctly

### Why make this change?

Prevents memory leaks by properly cleaning up pre-initialized adapters and avoids unnecessary API calls when users are not authenticated, improving performance and resource management.