### PR TITLE
artist detail page refactor

### DIFF
--- a/src/app/artists/ArtistDetail.tsx
+++ b/src/app/artists/ArtistDetail.tsx
@@ -1,18 +1,43 @@
-import { DataTable, type LibraryTrack } from "~/app/library/DataTable";
+import { type LibraryTrack } from "~/app/library/DataTable";
+import { PlaylistItem } from "~/app/playlist/[id]/PlaylistItem";
+import { Separator } from "~/components/ui/separator";
 
 type ArtistDetailProps = {
   artistName: string;
-  tracks: LibraryTrack[];
+  albums: {
+    albumName: string | null;
+    albumId: number | null;
+    playlistId: number;
+    tracks: LibraryTrack[];
+  }[];
 };
 
-export const ArtistDetail = ({ artistName, tracks }: ArtistDetailProps) => {
+export const ArtistDetail = ({ artistName, albums }: ArtistDetailProps) => {
   return (
-    <>
-      <h1 className="mt-7">{artistName}</h1>
-      <p className="opacity-70">{tracks.length} songs</p>
-      <div className="mx-auto mt-4 w-full max-w-4xl">
-        <DataTable data={tracks} />
+    <div className="px-2">
+      <h1 className="mt-7 font-bold">{artistName}</h1>
+      <div className="mt-4 w-full">
+        {albums.map((album, index) => (
+          <div key={index} className="mb-4">
+            <p className="text-m">{album.albumName ?? "No Album"}</p>
+            <Separator className="my-1" />
+            <div className="flex w-[90%] flex-col gap-2">
+              {album.tracks.map((track, index) => (
+                <PlaylistItem
+                  key={track.id}
+                  index={index}
+                  title={track.title}
+                  position={index}
+                  artists={track.artists}
+                  playlist={album.tracks}
+                  playlistId={album.playlistId}
+                  trackId={track.id}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
-    </>
+    </div>
   );
 };

--- a/src/app/artists/[id]/page.tsx
+++ b/src/app/artists/[id]/page.tsx
@@ -13,7 +13,5 @@ export default async function ArtistPage({
 
   if (!data) return <div>Artist not found</div>;
 
-  return (
-    <ArtistDetail artistName={data.artistName} tracks={data.tracks} />
-  );
+  return <ArtistDetail artistName={data.artistName} albums={data.albums} />;
 }

--- a/src/app/library/DataTable.tsx
+++ b/src/app/library/DataTable.tsx
@@ -1,23 +1,22 @@
 // see https://tanstack.com/table/v8/docs/introduction
 "use client";
 
-import { cn, formatSongTime } from "~/lib/utils";
-import { TrackOptions } from "~/app/_components/TrackOptions";
 import {
   flexRender,
   getCoreRowModel,
-  useReactTable,
-  getSortedRowModel,
-  getFilteredRowModel,
   getFacetedRowModel,
   getFacetedUniqueValues,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
   type ColumnDef,
+  type FilterFn,
   type SortingState,
   type VisibilityState,
-  type FilterFn,
 } from "@tanstack/react-table";
 import Link from "next/link";
 import { useState } from "react";
+import { TrackOptions } from "~/app/_components/TrackOptions";
 import {
   Table,
   TableBody,
@@ -26,9 +25,10 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/ui/table";
+import { cn, formatSongTime } from "~/lib/utils";
+import { DataTablePlay } from "./components/DataTablePlay";
 import { SortableColumnHeader } from "./components/SortableColumnHeader";
 import { DataTableToolbar } from "./components/Toolbar";
-import { DataTablePlay } from "./components/DataTablePlay";
 
 export type LibraryTrack = {
   id: number;
@@ -46,7 +46,7 @@ export type LibraryTrack = {
   position: number;
   albumId: number | null;
   isPlayable: boolean;
-  isInAnyPlaylist: boolean;
+  isInAnyPlaylist?: boolean;
 };
 
 const columns: ColumnDef<LibraryTrack>[] = [

--- a/src/app/playlist/[id]/PlaylistItem.tsx
+++ b/src/app/playlist/[id]/PlaylistItem.tsx
@@ -67,7 +67,7 @@ export const PlaylistItem = ({
   return (
     <div
       key={position}
-      className={`flex w-full max-w-full flex-row items-center justify-between p-1 text-sm md:w-[70%]`}
+      className={`flex w-full max-w-full flex-row items-center justify-between p-1 text-sm`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/src/app/playlist/[id]/page.tsx
+++ b/src/app/playlist/[id]/page.tsx
@@ -18,7 +18,7 @@ const Playlist = async ({ params }: { params: Promise<{ id: string }> }) => {
         playlistName={playlist.playlistName}
         playlist={playlist.playlistEntries}
       />
-      <div className="mx-auto flex flex-col items-center justify-center">
+      <div className="mx-auto flex w-[90%] flex-col items-center justify-center md:w-[70%]">
         {playlist.playlistEntries.map((song, index) => {
           return (
             <PlaylistItem

--- a/src/server/api/routers/artists.ts
+++ b/src/server/api/routers/artists.ts
@@ -1,5 +1,6 @@
-import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { z } from "zod";
+import { type LibraryTrack } from "~/app/library/DataTable";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 export const artistsRouter = createTRPCRouter({
   getAll: protectedProcedure.query(async ({ ctx }) => {
@@ -75,7 +76,7 @@ export const artistsRouter = createTRPCRouter({
         },
       });
 
-      const tracks = libraryTracks.map((track) => ({
+      const trackObjects = libraryTracks.map((track) => ({
         id: track.id,
         title: track.title,
         artists: track.artists.map((a) => ({
@@ -94,13 +95,44 @@ export const artistsRouter = createTRPCRouter({
         position: 1,
         albumId: track.album?.id ?? null,
         isPlayable: track.track.isPlayable,
-        // TODO: remove, jus tto make the table happy for now
-        isInAnyPlaylist: true,
       }));
+
+      const albumMap = new Map<
+        number | null,
+        {
+          albumName: string | null;
+          albumId: number | null;
+          tracks: LibraryTrack[];
+          playlistId: number;
+        }
+      >();
+
+      for (const track of trackObjects) {
+        const albumId = track.albumId;
+        const albumName = track.album;
+        if (!albumMap.has(albumId)) {
+          albumMap.set(albumId, {
+            albumName: albumName,
+            albumId: albumId,
+            playlistId: -1,
+            tracks: [],
+          });
+        }
+        albumMap.get(albumId)!.tracks.push(track);
+      }
+
+      const albums = Array.from(albumMap.values()).sort((a, b) => {
+        if (a.albumName === null) return 1;
+        if (b.albumName === null) return -1;
+        return a.albumName.localeCompare(b.albumName, undefined, {
+          sensitivity: "base",
+        });
+      });
 
       return {
         artistName: artist.name,
-        tracks,
+        artistId: artist.id,
+        albums,
       };
     }),
 });


### PR DESCRIPTION
### TL;DR

Refactored artist detail page to display tracks grouped by album instead of reusing the datatable

### What changed?

- Modified `ArtistDetail` component to accept albums array instead of flat tracks list
- Replaced `DataTable` with `PlaylistItem` components for track display
- Added album grouping logic in the artists API router that organizes tracks by album
- Updated `LibraryTrack` type to make `isInAnyPlaylist` optional
- Adjusted responsive width styling in playlist components

### How to test?

1. Navigate to an artist detail page (`/artists/[id]`)
2. Verify tracks are now grouped under their respective album names
3. Check that albums are sorted alphabetically with "No Album" appearing last
4. Ensure track playback functionality still works within each album group

### Why make this change?

This provides a more organized and intuitive way to browse an artist's catalog by grouping tracks under their albums, making it easier for users to find specific songs and understand the artist's discography structure.