### PR TITLE
fixing progress bar and finished player state

### DIFF
--- a/src/app/_components/player/components/desktop/ProgressBar.tsx
+++ b/src/app/_components/player/components/desktop/ProgressBar.tsx
@@ -1,6 +1,6 @@
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 import { Slider } from "~/components/ui/slider";
 import { formatSongTime } from "~/lib/utils";
-import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 
 interface ProgressBarProps {
   onProgressChange: (value: number[]) => void;
@@ -28,7 +28,7 @@ export const ProgressBar = ({
         value={[currentTime]}
         onValueChange={onProgressChange}
         onValueCommit={onProgressCommit}
-        max={duration}
+        max={duration > 0 ? duration : 1}
         step={1}
         className={location === "desktop" ? "w-80" : "w-full"}
         thumbClassName="hidden"

--- a/src/app/_components/player/components/mobile/PlayerCard.tsx
+++ b/src/app/_components/player/components/mobile/PlayerCard.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { Card } from "~/components/ui/card";
+import { Pause, Play } from "lucide-react";
 import { useState } from "react";
-import {
-  useMusicPlayerStore,
-  useMusicPlayerComputed,
-} from "~/app/_components/player/MusicPlayerStore";
-import { Progress } from "~/components/ui/progress";
-import { Button } from "~/components/ui/button";
-import { Play, Pause } from "lucide-react";
-import { PlayerSheet } from "./PlayerSheet";
 import { useShallow } from "zustand/react/shallow";
-import { play, pause } from "~/app/_components/player/musicPlayerActions";
+import { pause, play } from "~/app/_components/player/musicPlayerActions";
+import {
+  useMusicPlayerComputed,
+  useMusicPlayerStore,
+} from "~/app/_components/player/MusicPlayerStore";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Progress } from "~/components/ui/progress";
+import { PlayerSheet } from "./PlayerSheet";
 
 export const PlayerCard = () => {
   const [open, setOpen] = useState(false);
@@ -66,7 +66,7 @@ export const PlayerCard = () => {
           </div>
 
           <Progress
-            value={(currentTime / duration) * 100}
+            value={duration > 0 ? (currentTime / duration) * 100 : 0}
             className="rounded-none"
           />
         </div>

--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -88,8 +88,8 @@ export const previous = async (): Promise<void> => {
     if (hasPreviousTrack) {
       setCurrentTrackIndex(currentTrackIndex - 1);
 
-      setCurrentTime(0.01);
-      setDuration(0.9);
+      setCurrentTime(0);
+      setDuration(0);
 
       await play();
     }
@@ -113,9 +113,8 @@ export const next = async (): Promise<void> => {
   if (currentPlaylist && hasNextTrack && controller) {
     setCurrentTrackIndex(currentTrackIndex + 1);
 
-    // hacky loading state to get the slider and duration to properly display while loading next track
-    setCurrentTime(0.01);
-    setDuration(0.9);
+    setCurrentTime(0);
+    setDuration(0);
 
     await play();
   }
@@ -242,4 +241,19 @@ export const handleProgressCommit = async (value: number[]): Promise<void> => {
     setCurrentTime(value[0]);
     setIsSeeking(false);
   }
+};
+
+export const clearPlayerState = async (): Promise<void> => {
+  await pause();
+  useMusicPlayerStore.setState({
+    currentPlaylist: null,
+    originalPlaylist: null,
+    currentPlaylistId: null,
+    currentTrackIndex: 0,
+    isPlaying: false,
+    isLoaded: false,
+    isSeeking: false,
+    currentTime: 0,
+    duration: 0,
+  });
 };

--- a/src/app/_components/player/progressTimer.ts
+++ b/src/app/_components/player/progressTimer.ts
@@ -1,5 +1,5 @@
 import { useMusicPlayerStore } from "./MusicPlayerStore";
-import { next } from "./musicPlayerActions";
+import { clearPlayerState, next } from "./musicPlayerActions";
 
 // TODO: still may be a better way to do this, revisit
 let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -13,8 +13,6 @@ function tick(): void {
     controller,
     duration,
     setCurrentTime,
-    setDuration,
-    setIsPlaying,
     currentPlaylist,
     currentTrackIndex,
   } = state;
@@ -31,9 +29,7 @@ function tick(): void {
       if (hasNextTrack) {
         void next();
       } else {
-        setCurrentTime(0);
-        setDuration(0);
-        setIsPlaying(false);
+        void clearPlayerState();
       }
     }
   });


### PR DESCRIPTION
### TL;DR

Fixed division by zero errors in progress bars and improved player state management when tracks end.

### What changed?

- Added safeguards in `ProgressBar.tsx` and `PlayerCard.tsx` to prevent division by zero when duration is 0 by setting fallback values
- Removed hacky loading state values (0.01 and 0.9) from `previous()` and `next()` functions, replacing them with proper zero values
- Created new `clearPlayerState()` function to properly reset all player state when playlist ends
- Updated progress timer to use `clearPlayerState()` instead of manually setting individual state values
- Reorganized import statements for better consistency

### How to test?

1. Load a track and verify the progress bar displays correctly during playback
2. Skip to previous/next tracks and ensure smooth transitions without visual glitches
3. Let a playlist play to completion and verify the player properly resets to initial state
4. Test with tracks that may have zero or undefined duration values

### Why make this change?

The previous implementation had potential division by zero errors that could cause UI issues, and used temporary "hacky" values during track transitions that created poor user experience. The new approach provides more robust error handling and cleaner state management.