### PR TITLE
update soundcloud atrwork url fetch

### DIFF
--- a/src/server/lib/soundcloud/fetchSoundCloudTrackData.ts
+++ b/src/server/lib/soundcloud/fetchSoundCloudTrackData.ts
@@ -1,4 +1,5 @@
 import { type TrackData } from "~/server/lib/getTrackData";
+import { getBestArtworkUrl } from "./helperFunctions";
 
 interface SoundCloudResponse {
   title: string;
@@ -9,6 +10,7 @@ interface SoundCloudResponse {
     username: string;
   };
 }
+
 // TODO: make this still function without auth and test it
 export async function fetchSoundCloudTrackData(
   url: string,
@@ -67,7 +69,9 @@ export async function fetchSoundCloudTrackData(
     artist: data.user?.username ? [data.user.username] : [],
     album: "",
     duration: data.duration,
-    artworkUrl: data.artwork_url || "",
+    artworkUrl: data.artwork_url
+      ? await getBestArtworkUrl(data.artwork_url)
+      : "",
     sourceUrl: url,
     sourceId: data.id.toString(),
     source: "soundcloud" as const,

--- a/src/server/lib/soundcloud/helperFunctions.ts
+++ b/src/server/lib/soundcloud/helperFunctions.ts
@@ -1,0 +1,34 @@
+// https://stackoverflow.com/questions/9096120/how-to-get-thumbnail-of-soundcloud-using-api
+const buildUrlVariants = (url: string): string[] => {
+  if (!url) return [];
+
+  return [
+    url.replace("-large", "-t500x500"),
+    url.replace("-large", "-original"),
+  ];
+};
+
+const verifyArtworkUrl = async (url: string): Promise<boolean> => {
+  try {
+    const response = await fetch(url, {
+      method: "HEAD",
+      signal: AbortSignal.timeout(2000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+};
+
+export const getBestArtworkUrl = async (url: string): Promise<string> => {
+  const originalUrl = url;
+  const urlVariants = buildUrlVariants(url);
+
+  for (const url of urlVariants) {
+    if (await verifyArtworkUrl(url)) {
+      return url;
+    }
+  }
+
+  return originalUrl;
+};


### PR DESCRIPTION
### TL;DR

Improved SoundCloud artwork quality by attempting to fetch higher resolution versions before falling back to the original URL.

### What changed?

Added a new helper function `getBestArtworkUrl` that tries to fetch higher quality artwork variants (t500x500 and original) by replacing the "-large" suffix in SoundCloud artwork URLs. The function verifies each URL variant with a HEAD request and returns the first working higher quality version, or falls back to the original URL if none are available.

### How to test?

Test with SoundCloud tracks that have artwork to verify that higher resolution images are being fetched when available. Check that the fallback to original artwork URL works when higher quality variants are not accessible.

### Why make this change?

SoundCloud's API often returns lower quality "-large" artwork URLs by default, but higher quality variants may be available at the same base URL with different suffixes. This enhancement improves the visual quality of track artwork displayed in the application.