### PR TITLE
separation of artist item and playlist item

### DIFF
--- a/src/app/artists/ArtistDetail.tsx
+++ b/src/app/artists/ArtistDetail.tsx
@@ -1,6 +1,6 @@
 import { type LibraryTrack } from "~/app/library/DataTable";
-import { PlaylistItem } from "~/app/playlist/[id]/PlaylistItem";
 import { Separator } from "~/components/ui/separator";
+import { ArtistItem } from "./ArtistItem";
 
 type ArtistDetailProps = {
   artistName: string;
@@ -23,7 +23,7 @@ export const ArtistDetail = ({ artistName, albums }: ArtistDetailProps) => {
             <Separator className="my-1" />
             <div className="flex w-[90%] flex-col gap-2">
               {album.tracks.map((track, index) => (
-                <PlaylistItem
+                <ArtistItem
                   key={track.id}
                   index={index}
                   title={track.title}

--- a/src/app/artists/ArtistItem.tsx
+++ b/src/app/artists/ArtistItem.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import Lottie from "lottie-react";
+import { Play } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { reserveCurrentAndShuffleRest } from "~/app/_components/player/helpers/shuffleFunctions";
+import { play } from "~/app/_components/player/musicPlayerActions";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
+import type { PlaylistTrack } from "~/app/_components/player/types/player";
+import { TrackOptions } from "~/app/_components/TrackOptions";
+import SoundWave from "~/app/playlist/[id]/SoundWave.json";
+
+interface PlaylistItemProps {
+  index: number;
+  title: string;
+  position: number;
+  artists: { artistId: number; artistName: string }[];
+  playlist: PlaylistTrack[];
+  playlistId: number;
+  trackId: number;
+}
+
+export const ArtistItem = ({
+  index,
+  title,
+  position,
+  artists,
+  playlist,
+  playlistId,
+  trackId,
+}: PlaylistItemProps) => {
+  const [hovered, setHovered] = useState(false);
+
+  const { currentPlaylistId, currentTrackIndex, currentPlaylist, isShuffleOn } =
+    useMusicPlayerStore(
+      useShallow((s) => ({
+        currentPlaylistId: s.currentPlaylistId,
+        currentTrackIndex: s.currentTrackIndex,
+        currentPlaylist: s.currentPlaylist,
+        isShuffleOn: s.isShuffleOn,
+      })),
+    );
+  const { setCurrentPlaylist, setCurrentTrackIndex, setOriginalPlaylist } =
+    useMusicPlayerStore.getState();
+
+  const isCurrentTrack =
+    currentPlaylistId === playlistId &&
+    currentPlaylist![currentTrackIndex]!.trackId === trackId;
+
+  const handlePlay = async () => {
+    setCurrentPlaylist(playlist, playlistId);
+    setOriginalPlaylist(playlist);
+    setCurrentTrackIndex(index);
+
+    if (isShuffleOn) {
+      const shuffledPlaylist = reserveCurrentAndShuffleRest();
+      setCurrentPlaylist(shuffledPlaylist, playlistId, {
+        newTrackIndex: 0,
+      });
+    }
+
+    await play();
+  };
+
+  return (
+    <div
+      key={position}
+      className={`flex w-full max-w-full flex-row items-center justify-between p-1 text-sm`}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div
+        className="flex min-w-0 flex-1 flex-row items-center gap-4"
+        onClick={handlePlay}
+      >
+        <div className="flex w-8 shrink-0 items-center justify-center">
+          {isCurrentTrack ? (
+            <Lottie animationData={SoundWave} loop={true} />
+          ) : hovered ? (
+            <Play className="size-4" />
+          ) : (
+            <p>{index + 1}</p>
+          )}
+        </div>
+        <div className="flex min-w-0 flex-col">
+          <p className="truncate">{title}</p>
+          <p className="truncate">
+            {artists.map((artist, index) => {
+              return (
+                <Link
+                  href={`/artists/${artist.artistId}`}
+                  key={artist.artistId}
+                  className="text-muted-foreground hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {artist.artistName}
+                  {index < artists.length - 1 && ", "}
+                </Link>
+              );
+            })}
+          </p>
+        </div>
+      </div>
+
+      <TrackOptions song={playlist[index]!} />
+    </div>
+  );
+};


### PR DESCRIPTION
### TL;DR

Created a dedicated `ArtistItem` component for displaying tracks in artist detail views, replacing the generic `PlaylistItem` component. In the future they will branch out, the logic will probably be the same so making a hook could be good but for now it's just these two places.

### What changed?

- Created a new `ArtistItem`, a duplicate of playlist item, for the artist detail page 

### How to test?

1. Navigate to an artist detail page
2. Verify that tracks are displayed correctly with proper numbering and metadata
3. Test hover interactions to ensure play button appears
4. Click on tracks to verify playback functionality works
5. Test that artist name links are clickable and navigate correctly

### Why make this change?

This change improves code organization by creating a component specifically tailored for artist track listings, rather than reusing a playlist-focused component. This allows for better maintainability and potential future customizations specific to artist views without affecting playlist functionality.