### PR TITLE
disabling controls if no current playlist

### DIFF
--- a/src/app/_components/player/components/desktop/PlaybackControl.tsx
+++ b/src/app/_components/player/components/desktop/PlaybackControl.tsx
@@ -29,6 +29,7 @@ export const PlaybackControl = ({
 }: PlaybackControlProps) => {
   const isPlaying = useMusicPlayerStore((s) => s.isPlaying);
   const isShuffleOn = useMusicPlayerStore((s) => s.isShuffleOn);
+  const currentPlaylist = useMusicPlayerStore((s) => s.currentPlaylist);
   const { hasNextTrack } = useMusicPlayerComputed();
 
   return (
@@ -40,11 +41,17 @@ export const PlaybackControl = ({
       >
         <ArrowsCrossingIcon />
       </Button>
-      <Button onClick={onPrevious} variant="ghost" className="px-2!">
+      <Button
+        disabled={!currentPlaylist}
+        onClick={onPrevious}
+        variant="ghost"
+        className="px-2!"
+      >
         <BackwardIcon className="size-5" fill="#fff" />
       </Button>
 
       <Button
+        disabled={!currentPlaylist}
         onClick={isPlaying ? onPause : onPlay}
         variant="ghost"
         size="icon"
@@ -59,7 +66,7 @@ export const PlaybackControl = ({
       <Button
         onClick={onNext}
         variant="ghost"
-        disabled={!hasNextTrack}
+        disabled={!hasNextTrack || !currentPlaylist}
         className="px-2!"
       >
         <ForwardIcon className="size-5" fill="#fff" />

--- a/src/app/_components/player/components/mobile/PlayerCard.tsx
+++ b/src/app/_components/player/components/mobile/PlayerCard.tsx
@@ -15,14 +15,16 @@ import { PlayerSheet } from "./PlayerSheet";
 
 export const PlayerCard = () => {
   const [open, setOpen] = useState(false);
-  const { loadedOnce, isPlaying, duration, currentTime } = useMusicPlayerStore(
-    useShallow((s) => ({
-      loadedOnce: s.loadedOnce,
-      isPlaying: s.isPlaying,
-      duration: s.duration,
-      currentTime: s.currentTime,
-    })),
-  );
+  const { loadedOnce, isPlaying, duration, currentTime, currentPlaylist } =
+    useMusicPlayerStore(
+      useShallow((s) => ({
+        loadedOnce: s.loadedOnce,
+        isPlaying: s.isPlaying,
+        duration: s.duration,
+        currentTime: s.currentTime,
+        currentPlaylist: s.currentPlaylist,
+      })),
+    );
 
   const { currentTrack } = useMusicPlayerComputed();
 
@@ -47,6 +49,7 @@ export const PlayerCard = () => {
               </p>
             </div>
             <Button
+              disabled={!currentPlaylist}
               onClick={async (e) => {
                 e.stopPropagation();
                 if (isPlaying) {

--- a/src/app/_components/player/components/mobile/PlayerSheet.tsx
+++ b/src/app/_components/player/components/mobile/PlayerSheet.tsx
@@ -26,6 +26,7 @@ export const PlayerSheet = ({
 }) => {
   const isPlaying = useMusicPlayerStore((s) => s.isPlaying);
   const isShuffleOn = useMusicPlayerStore((s) => s.isShuffleOn);
+  const currentPlaylist = useMusicPlayerStore((s) => s.currentPlaylist);
 
   const { currentTrack, hasNextTrack } = useMusicPlayerComputed();
 
@@ -56,17 +57,29 @@ export const PlayerSheet = ({
             </Button>
           </div>
           <div className="align-center flex justify-between">
-            <Button variant="ghost" onClick={previous}>
+            <Button
+              variant="ghost"
+              onClick={previous}
+              disabled={!currentPlaylist}
+            >
               <SkipBack className="size-5" fill="#fff" />
             </Button>
-            <Button variant="ghost" onClick={isPlaying ? pause : play}>
+            <Button
+              variant="ghost"
+              onClick={isPlaying ? pause : play}
+              disabled={!currentPlaylist}
+            >
               {isPlaying ? (
                 <Pause className="size-5" fill="#fff" />
               ) : (
                 <Play className="size-5" fill="#fff" />
               )}
             </Button>
-            <Button variant="ghost" onClick={next} disabled={!hasNextTrack}>
+            <Button
+              variant="ghost"
+              onClick={next}
+              disabled={!hasNextTrack || !currentPlaylist}
+            >
               <SkipForward className="size-5" fill="#fff" />
             </Button>
           </div>


### PR DESCRIPTION
### TL;DR

Disabled music player controls when no playlist is loaded to prevent user interaction with non-functional buttons.

### What changed?

Added `currentPlaylist` state from the music player store and used it to conditionally disable playback controls across both desktop and mobile interfaces. The previous, play/pause, and next buttons are now disabled when `currentPlaylist` is falsy. The next button maintains its existing `hasNextTrack` condition in addition to the playlist check.

### Why make this change?

This prevents users from attempting to interact with playback controls when there's no active playlist, which would result in non-functional button presses and a poor user experience. The disabled state provides clear visual feedback about the player's current state.