### PR TITLE
playlist page ui rework

### DIFF
--- a/src/app/_components/forms/EditTrack.tsx
+++ b/src/app/_components/forms/EditTrack.tsx
@@ -1,19 +1,18 @@
 "use client";
 
 import { ArrowRight } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { PlaylistTrack } from "~/app/_components/player/types/player";
+import { Button } from "~/components/ui/button";
 import {
   Sheet,
   SheetContent,
-  SheetTitle,
   SheetDescription,
+  SheetTitle,
 } from "~/components/ui/sheet";
-import { TrackForm } from "./TrackForm";
 import { api } from "~/trpc/react";
-import { type AddTrackFormData } from "./TrackForm";
-import type { PlaylistTrack } from "~/app/_components/player/types/player";
-import { useRouter } from "next/navigation";
-import { Button } from "~/components/ui/button";
-import { toast } from "sonner";
+import { TrackForm, type AddTrackFormData } from "./TrackForm";
 
 export const EditTrack = ({
   open,

--- a/src/app/_components/player/components/desktop/MusicPlayer.tsx
+++ b/src/app/_components/player/components/desktop/MusicPlayer.tsx
@@ -62,11 +62,11 @@ export const MusicPlayer = () => {
         <div className="justify-self-end">
           <div className="flex items-center gap-2">
             <Previous onPrevious={previous} />
-            <span>/</span>
+            <span className="text-muted-foreground text-xs">/</span>
             <Next onNext={next} />
-            <span>/</span>
+            <span className="text-muted-foreground text-xs">/</span>
             <Shuffle />
-            <span>/</span>
+            <span className="text-muted-foreground text-xs">/</span>
             <Button
               variant="ghost"
               className="h-4 p-0!"

--- a/src/app/_components/player/components/desktop/Shuffle.tsx
+++ b/src/app/_components/player/components/desktop/Shuffle.tsx
@@ -16,7 +16,7 @@ export const Shuffle = () => {
         isShuffleOn ? "text-amber-600" : "text-primary",
       )}
     >
-      <ArrowsCrossingIcon fill="#fff" />
+      <ArrowsCrossingIcon />
     </Button>
   );
 };

--- a/src/app/playlist/[id]/ArtworkDisplay.tsx
+++ b/src/app/playlist/[id]/ArtworkDisplay.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
+
+export const ArtworkDisplay = () => {
+  const currentPlaylist = useMusicPlayerStore((s) => s.currentPlaylist);
+  const currentTrackIndex = useMusicPlayerStore((s) => s.currentTrackIndex);
+
+  const artworkUrl = currentPlaylist?.[currentTrackIndex]?.artworkUrl;
+  return (
+    <div className="aspect-square w-full">
+      {artworkUrl ? (
+        <img
+          src={artworkUrl}
+          alt="Artwork"
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        <div className="border-muted flex h-full w-full items-center justify-center border">
+          <p className="text-muted-foreground">No artwork</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/playlist/[id]/PlaylistHeader.tsx
+++ b/src/app/playlist/[id]/PlaylistHeader.tsx
@@ -51,9 +51,9 @@ export const PlaylistHeader = ({
 
   return (
     <>
-      <div className="mx-auto my-2 w-full max-w-120">
+      <div className="w-full">
         <div
-          className="flex min-h-10 items-center justify-between"
+          className="items-top flex min-h-10 justify-between"
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >

--- a/src/app/playlist/[id]/PlaylistItem.tsx
+++ b/src/app/playlist/[id]/PlaylistItem.tsx
@@ -1,16 +1,13 @@
 "use client";
 
-import Lottie from "lottie-react";
-import { Play } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { reserveCurrentAndShuffleRest } from "~/app/_components/player/helpers/shuffleFunctions";
 import { play } from "~/app/_components/player/musicPlayerActions";
 import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 import type { PlaylistTrack } from "~/app/_components/player/types/player";
 import { TrackOptions } from "~/app/_components/TrackOptions";
-import SoundWave from "./SoundWave.json";
+import { cn } from "~/lib/utils";
 
 interface PlaylistItemProps {
   index: number;
@@ -31,8 +28,6 @@ export const PlaylistItem = ({
   playlistId,
   trackId,
 }: PlaylistItemProps) => {
-  const [hovered, setHovered] = useState(false);
-
   const { currentPlaylistId, currentTrackIndex, currentPlaylist, isShuffleOn } =
     useMusicPlayerStore(
       useShallow((s) => ({
@@ -67,44 +62,44 @@ export const PlaylistItem = ({
   return (
     <div
       key={position}
-      className={`flex w-full max-w-full flex-row items-center justify-between p-1 text-sm`}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      className={cn(
+        "md:hover:bg-accent grid w-full grid-cols-[1fr_1fr_auto] items-center text-sm md:grid-cols-[3fr_2fr_auto]",
+      )}
+      onClick={handlePlay}
     >
-      <div
-        className="flex min-w-0 flex-1 flex-row items-center gap-4"
-        onClick={handlePlay}
+      <p
+        className={cn(
+          "truncate",
+          isCurrentTrack ? "font-semibold text-amber-700" : "",
+        )}
       >
-        <div className="flex w-8 shrink-0 items-center justify-center">
-          {isCurrentTrack ? (
-            <Lottie animationData={SoundWave} loop={true} />
-          ) : hovered ? (
-            <Play className="size-4" />
-          ) : (
-            <p>{index + 1}</p>
-          )}
-        </div>
-        <div className="flex min-w-0 flex-col">
-          <p className="truncate">{title}</p>
-          <p className="truncate">
-            {artists.map((artist, index) => {
-              return (
-                <Link
-                  href={`/artists/${artist.artistId}`}
-                  key={artist.artistId}
-                  className="text-muted-foreground hover:underline"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {artist.artistName}
-                  {index < artists.length - 1 && ", "}
-                </Link>
-              );
-            })}
-          </p>
-        </div>
-      </div>
+        {title}
+      </p>
 
-      <TrackOptions song={playlist[index]!} />
+      <p
+        className={cn(
+          "truncate pr-6 text-end md:text-start",
+          isCurrentTrack ? "font-semibold" : "",
+        )}
+      >
+        {artists.map((artist, index) => {
+          return (
+            <Link
+              href={`/artists/${artist.artistId}`}
+              key={artist.artistId}
+              className="text-muted-foreground hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {artist.artistName}
+              {index < artists.length - 1 && ", "}
+            </Link>
+          );
+        })}
+      </p>
+
+      <div onClick={(e) => e.stopPropagation()}>
+        <TrackOptions song={playlist[index]!} />
+      </div>
     </div>
   );
 };

--- a/src/app/playlist/[id]/page.tsx
+++ b/src/app/playlist/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { api } from "~/trpc/server";
-import { PlaylistItem } from "./PlaylistItem";
-
+import { ArtworkDisplay } from "./ArtworkDisplay";
 import { PlaylistHeader } from "./PlaylistHeader";
+import { PlaylistItem } from "./PlaylistItem";
 
 const Playlist = async ({ params }: { params: Promise<{ id: string }> }) => {
   const { id: playlistId } = await params;
@@ -12,28 +12,33 @@ const Playlist = async ({ params }: { params: Promise<{ id: string }> }) => {
   if (!playlist) return <div>Playlist not found</div>;
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <div className="shrink-0">
-        <PlaylistHeader
-          playlistId={playlist.playlistId}
-          playlistName={playlist.playlistName}
-        />
+    <div className="grid h-full min-h-0 w-full grid-cols-1 grid-rows-1 p-2 md:grid-cols-[2fr_1fr]">
+      <div className="flex h-full min-h-0 flex-col overflow-hidden pr-4">
+        <div className="shrink-0">
+          <PlaylistHeader
+            playlistId={playlist.playlistId}
+            playlistName={playlist.playlistName}
+          />
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col items-center gap-4 overflow-y-auto md:gap-2">
+          {playlist.playlistEntries.map((song, index) => {
+            return (
+              <PlaylistItem
+                key={song.position}
+                index={index}
+                title={song.title}
+                position={song.position}
+                artists={song.artists}
+                playlist={playlist.playlistEntries}
+                playlistId={song.playlistId}
+                trackId={song.trackId}
+              />
+            );
+          })}
+        </div>
       </div>
-      <div className="mx-auto flex min-h-0 w-[90%] flex-1 flex-col items-center overflow-y-auto md:w-[70%]">
-        {playlist.playlistEntries.map((song, index) => {
-          return (
-            <PlaylistItem
-              key={song.position}
-              index={index}
-              title={song.title}
-              position={song.position}
-              artists={song.artists}
-              playlist={playlist.playlistEntries}
-              playlistId={song.playlistId}
-              trackId={song.trackId}
-            />
-          );
-        })}
+      <div className="hidden md:block">
+        <ArtworkDisplay />
       </div>
     </div>
   );


### PR DESCRIPTION
### TL;DR

Redesigned the playlist page layout with a two-column grid and improved the music player controls styling.

### What changed?

- Created new `ArtworkDisplay` component that shows the current track's artwork or a placeholder
- Redesigned `PlaylistItem` to use a grid layout instead of flexbox with hover states
- Converted playlist page to a two-column layout with tracks on the left and artwork display on the right (desktop only)
- Updated playlist header alignment and removed fixed max-width constraint

### How to test?

1. Navigate to any playlist page and verify the new two-column layout appears on desktop
2. Check that track artwork displays in the right column when available
3. Test playlist item interactions (clicking tracks, artist links, and track options)
4. Verify music player controls show properly styled separators
5. Test the shuffle button functionality and visual states

### Why make this change?

This redesign improves the visual hierarchy and user experience of playlist pages by providing a cleaner grid-based layout and dedicated space for artwork display. The styling improvements to the music player controls create better visual separation and consistency with the overall design system.