### PR TITLE
remove optional relation on album and artist

### DIFF
--- a/prisma/migrations/20260402215848_remove_optional_user_relation_on_album_and_artist/migration.sql
+++ b/prisma/migrations/20260402215848_remove_optional_user_relation_on_album_and_artist/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Made the column `userId` on table `Album` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `userId` on table `Artist` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Album" ALTER COLUMN "userId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Artist" ALTER COLUMN "userId" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,8 +86,8 @@ model Album {
 
     name      String
 
-    userId    Int?
-    user      User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
+    userId    Int
+    user      User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
     libraryTracks LibraryTrack[]
 
@@ -100,8 +100,8 @@ model Artist {
 
     name      String
 
-    userId    Int?
-    user      User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
+    userId    Int
+    user      User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
     libraryTracks LibraryTrackArtist[]
 


### PR DESCRIPTION
### TL;DR

Made the `userId` field required on `Album` and `Artist` models, removing the optional user relationship.

### What changed?

- Changed `userId` from optional (`Int?`) to required (`Int`) on both `Album` and `Artist` models
- Updated the corresponding `user` relation fields from optional (`User?`) to required (`User`)
- Added a database migration to enforce the NOT NULL constraint on these columns

### How to test?

- Run the migration to ensure existing data doesn't have NULL `userId` values
- Verify that creating new albums or artists without a `userId` now fails
- Test that all existing album and artist queries still work correctly
- Confirm that cascade deletion still functions properly when users are deleted

### Why make this change?

This enforces data integrity by ensuring every album and artist must be associated with a user, preventing orphaned records and simplifying the data model by removing nullable relationships.