### PR TITLE
clean up after migrations

### DIFF
--- a/src/server/api/routers/artists.ts
+++ b/src/server/api/routers/artists.ts
@@ -49,7 +49,7 @@ export const artistsRouter = createTRPCRouter({
     .input(z.object({ artistId: z.number() }))
     .query(async ({ ctx, input }) => {
       const artist = await ctx.db.artist.findUnique({
-        where: { id: input.artistId },
+        where: { id: input.artistId, userId: ctx.user.id },
       });
       if (!artist) return null;
 

--- a/src/server/api/routers/tracks.ts
+++ b/src/server/api/routers/tracks.ts
@@ -50,6 +50,7 @@ export const tracksRouter = createTRPCRouter({
           let artist = await tx.artist.findFirst({
             where: {
               name: artistName,
+              userId,
             },
           });
 
@@ -58,6 +59,7 @@ export const tracksRouter = createTRPCRouter({
             artist = await tx.artist.create({
               data: {
                 name: artistName,
+                userId,
               },
             });
           }
@@ -72,6 +74,7 @@ export const tracksRouter = createTRPCRouter({
           album = await tx.album.findFirst({
             where: {
               name: input.album,
+              userId,
             },
           });
 
@@ -80,6 +83,7 @@ export const tracksRouter = createTRPCRouter({
             album = await tx.album.create({
               data: {
                 name: input.album,
+                userId,
               },
             });
           }
@@ -138,6 +142,7 @@ export const tracksRouter = createTRPCRouter({
           let artist = await tx.artist.findFirst({
             where: {
               name: artistName,
+              userId,
             },
           });
 
@@ -146,6 +151,7 @@ export const tracksRouter = createTRPCRouter({
             artist = await tx.artist.create({
               data: {
                 name: artistName,
+                userId,
               },
             });
           }
@@ -160,6 +166,7 @@ export const tracksRouter = createTRPCRouter({
           album = await tx.album.findFirst({
             where: {
               name: input.album,
+              userId,
             },
           });
 
@@ -168,6 +175,7 @@ export const tracksRouter = createTRPCRouter({
             album = await tx.album.create({
               data: {
                 name: input.album,
+                userId,
               },
             });
           }


### PR DESCRIPTION
### TL;DR

Added user-scoped data access to ensure artists and albums are isolated per user

### What changed?

- Added `userId: ctx.user.id` filter to artist lookup query in artists router
- Added `userId` field to all artist and album `findFirst` and `create` operations in tracks router
- Ensures artists and albums are created and retrieved only within the context of the authenticated user

### How to test?

1. Create tracks with artists/albums as different users
2. Verify that each user only sees their own artists and albums
3. Test artist lookup by ID to confirm it only returns artists belonging to the authenticated user
4. Attempt to access another user's artist by ID and verify it returns null

### Why make this change?

This implements proper data isolation between users, preventing users from accessing or modifying artists and albums that belong to other users. Without this change, the application would have a security vulnerability where users could potentially see or interact with data from other users.