### PR TITLE
update toasts all to bot right

### DIFF
--- a/src/app/_components/forms/AddTrack.tsx
+++ b/src/app/_components/forms/AddTrack.tsx
@@ -1,22 +1,21 @@
 "use client";
 
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "~/components/ui/button";
 import {
   Sheet,
   SheetContent,
-  SheetTitle,
   SheetDescription,
+  SheetTitle,
 } from "~/components/ui/sheet";
-import { LinkStep } from "./LinkStep";
-import { TrackForm } from "./TrackForm";
-import { api } from "~/trpc/react";
 import { type TrackData } from "~/server/lib/getTrackData";
-import { type AddTrackFormData } from "./TrackForm";
+import { api } from "~/trpc/react";
+import { LinkStep } from "./LinkStep";
 import { PlaylistSelector } from "./PlaylistSelector";
-import { Button } from "~/components/ui/button";
-import { toast } from "sonner";
-import { ArrowRight, ArrowLeft } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { TrackForm, type AddTrackFormData } from "./TrackForm";
 
 export const AddTrack = ({
   open,
@@ -67,12 +66,12 @@ export const AddTrack = ({
       setSelectedPlaylists([]);
       onOpenChange(false);
       // TODO
-      toast.success("Song added", { position: "top-right" });
+      toast.success("Song added", { position: "bottom-right" });
     },
     onError: (error) => {
       console.error(error);
       //  TODO
-      toast.error("Error adding song", { position: "top-right" });
+      toast.error("Error adding song", { position: "bottom-right" });
     },
   });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({
               </div>
             </GlobalContextMenu>
 
-            <Toaster position="top-left" />
+            <Toaster position="bottom-right" />
 
             {/* needed for iframe insert and media session control */}
             <AppMediaAnchor />


### PR DESCRIPTION
### TL;DR

Changed toast notification position from top-left/top-right to bottom-right across the application

### What changed?

- Updated the global Toaster component position from "top-left" to "bottom-right" in the main layout
- Modified toast notifications in the AddTrack component to use "bottom-right" position instead of "top-right"
- Reorganized imports in AddTrack.tsx to follow a more consistent ordering

### How to test?

1. Navigate to the add track functionality
2. Attempt to add a song successfully to verify the success toast appears in the bottom-right
3. Trigger an error condition when adding a song to verify the error toast appears in the bottom-right
4. Test any other toast notifications throughout the app to ensure they appear in the bottom-right corner

### Why make this change?

This change standardizes the toast notification position across the entire application, providing a consistent user experience. Bottom-right positioning is often preferred as it's less intrusive to the main content area and follows common UI patterns.