### PR TITLE
attempt improve spotify track switching

### DIFF
--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -86,6 +86,7 @@ export const previous = async (): Promise<void> => {
     }
 
     if (hasPreviousTrack) {
+      await controller.pause();
       setCurrentTrackIndex(currentTrackIndex - 1);
 
       setCurrentTime(0);
@@ -111,6 +112,7 @@ export const next = async (): Promise<void> => {
     : false;
 
   if (currentPlaylist && hasNextTrack && controller) {
+    await controller.pause(); // spotify async, starting early in the chain
     setCurrentTrackIndex(currentTrackIndex + 1);
 
     setCurrentTime(0);


### PR DESCRIPTION
### TL;DR

Added pause calls before track navigation to prevent audio overlap during track transitions.

### What changed?

Added `await controller.pause()` calls at the beginning of both the `previous()` and `next()` functions in the music player actions. The pause call in the `next()` function includes a comment noting that Spotify's async operations benefit from starting early in the chain.

### How to test?

1. Play a track in the music player
2. Use the previous/next track controls while audio is playing
3. Verify that the current track pauses before switching to the new track
4. Confirm there's no audio overlap between tracks during navigation

### Why make this change?

This prevents audio overlap issues when users navigate between tracks while music is playing. By pausing the current track before switching, we ensure a clean transition and avoid having multiple tracks playing simultaneously.