### PR TITLE
fix spotify desync on next/prev

### DIFF
--- a/src/app/_components/player/adapters/SpotifyAdapter.ts
+++ b/src/app/_components/player/adapters/SpotifyAdapter.ts
@@ -93,6 +93,7 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
   private isReady: boolean = false;
   private isInitialized: boolean = false;
   private deviceId: string | null = null;
+  private lastLoadedTrackId: string | null = null; // from the last successful 'loadNewTrack', used to defer 'resume()' until the SDK matches.
 
   async initializeWidget(trackId?: string): Promise<void> {
     return new Promise((resolve) => {
@@ -126,9 +127,16 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
 
         player.addListener("player_state_changed", async (data) => {
           if (data === null) return;
+          const { currentPlaylist, currentTrackIndex } =
+            useMusicPlayerStore.getState();
+          const expectedId =
+            currentPlaylist?.[currentTrackIndex]?.sourceId ?? null;
+          const currentId = data.track_window?.current_track?.id ?? null;
           if (!data.paused && !data.loading) {
-            useMusicPlayerStore.getState().setIsPlaying(true);
-            void startAnchorAndUpdateMediaSession();
+            if (expectedId && currentId === expectedId) {
+              useMusicPlayerStore.getState().setIsPlaying(true);
+              void startAnchorAndUpdateMediaSession();
+            }
           }
         });
 
@@ -219,6 +227,7 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
       );
       return;
     }
+    this.lastLoadedTrackId = trackId;
     this.isReady = true;
   }
 
@@ -228,6 +237,9 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
       return;
     }
 
+    if (this.lastLoadedTrackId) {
+      await this.waitUntilCurrentTrackIs(this.lastLoadedTrackId);
+    }
     await this.player.resume();
   }
 
@@ -294,6 +306,22 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
       return;
     }
     await this.player.activateElement();
+  }
+
+  private async waitUntilCurrentTrackIs(trackId: string): Promise<void> {
+    if (!this.player) return;
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      const state = await this.player.getCurrentState();
+      if (state?.track_window?.current_track?.id === trackId) {
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    console.warn(
+      "Spotify: timed out waiting for track switch; track id:",
+      trackId,
+    );
   }
 
   readonly sound: null = null;

--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -86,7 +86,6 @@ export const previous = async (): Promise<void> => {
     }
 
     if (hasPreviousTrack) {
-      await controller.pause();
       setCurrentTrackIndex(currentTrackIndex - 1);
 
       setCurrentTime(0);
@@ -112,7 +111,6 @@ export const next = async (): Promise<void> => {
     : false;
 
   if (currentPlaylist && hasNextTrack && controller) {
-    await controller.pause(); // spotify async, starting early in the chain
     setCurrentTrackIndex(currentTrackIndex + 1);
 
     setCurrentTime(0);


### PR DESCRIPTION
### TL;DR

Fixed Spotify player race condition by tracking loaded tracks and deferring resume until track switching completes

### What changed?

- Added `lastLoadedTrackId` tracking in SpotifyAdapter to store the ID of the most recently loaded track
- Enhanced `player_state_changed` listener to verify the current track matches the expected track before setting playing state
- Implemented `waitUntilCurrentTrackIs()` method that polls the Spotify SDK until the correct track is active (with 5-second timeout)
- Modified `resume()` to wait for track switching completion before resuming playback
- Removed premature `pause()` calls from `previous()` and `next()` functions in musicPlayerActions

### Why make this change?

Previously when advancing the previous spotify track, the previous track would continue playing for a second before switching over, causing a weird audio desync. 