### PR TITLE
buns fix to spotify bug on their end

### DIFF
--- a/src/app/_components/player/adapters/SpotifyAdapter.ts
+++ b/src/app/_components/player/adapters/SpotifyAdapter.ts
@@ -74,6 +74,16 @@ type PlayerData = {
   device_id: string;
 };
 
+/**
+ * Normalize titles when comparing our playlist row to SDK `current_track` — Spotify may resolve
+ * playback to a different id than we stored (alternate releases, clean vs explicit, etc.).
+ * Brittle fix but idc
+ * https://github.com/steffancross/aggregate/issues/267
+ */
+function normalizedTrackTitle(title: string): string {
+  return title.trim().toLowerCase();
+}
+
 type PlayerEventMap = {
   ready: PlayerData;
   not_ready: PlayerData;
@@ -127,13 +137,29 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
 
         player.addListener("player_state_changed", async (data) => {
           if (data === null) return;
+
           const { currentPlaylist, currentTrackIndex } =
             useMusicPlayerStore.getState();
-          const expectedId =
-            currentPlaylist?.[currentTrackIndex]?.sourceId ?? null;
+          const expectedTrack = currentPlaylist?.[currentTrackIndex];
+          const expectedId = expectedTrack?.sourceId ?? null;
+          const expectedTitle = expectedTrack?.title ?? null;
+
           const currentId = data.track_window?.current_track?.id ?? null;
+          const currentTitle = data.track_window?.current_track?.name ?? null;
+          const idMatches =
+            Boolean(expectedId) &&
+            Boolean(currentId) &&
+            currentId === expectedId;
+          const titleMatches =
+            expectedTitle != null &&
+            currentTitle != null &&
+            expectedTitle.trim() !== "" &&
+            currentTitle.trim() !== "" &&
+            normalizedTrackTitle(expectedTitle) ===
+              normalizedTrackTitle(currentTitle);
+
           if (!data.paused && !data.loading) {
-            if (expectedId && currentId === expectedId) {
+            if (idMatches || titleMatches) {
               useMusicPlayerStore.getState().setIsPlaying(true);
               void startAnchorAndUpdateMediaSession();
             }
@@ -313,7 +339,19 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
     const deadline = Date.now() + 5_000;
     while (Date.now() < deadline) {
       const state = await this.player.getCurrentState();
-      if (state?.track_window?.current_track?.id === trackId) {
+      const current = state?.track_window?.current_track;
+      if (current?.id === trackId) {
+        return;
+      }
+      const { currentPlaylist, currentTrackIndex } =
+        useMusicPlayerStore.getState();
+      const expectedTitle = currentPlaylist?.[currentTrackIndex]?.title;
+      if (
+        expectedTitle?.trim() &&
+        current?.name?.trim() &&
+        normalizedTrackTitle(expectedTitle) ===
+          normalizedTrackTitle(current.name)
+      ) {
         return;
       }
       await new Promise((r) => setTimeout(r, 50));


### PR DESCRIPTION
### TL;DR

Added fallback track matching by normalized title when Spotify track IDs don't match expected values.

### What changed?

- Added `normalizedTrackTitle()` function that trims whitespace and converts titles to lowercase for comparison
- Enhanced the player state change listener to check both track ID and normalized title matches
- Updated `waitForTrackToLoad()` to also verify tracks using normalized title comparison as a fallback
- Track matching now succeeds if either the Spotify track ID matches or the normalized titles match

### How to test?

1. Play tracks that might resolve to different Spotify IDs than stored (alternate releases, clean vs explicit versions)
2. Verify the player correctly identifies when the expected track is playing
3. Test that track loading detection works for tracks with title mismatches but same content

### Why make this change?

Spotify sometimes resolves playback to different track IDs than what we store in our playlist (due to alternate releases, clean vs explicit versions, etc.). This causes the player to incorrectly think a different track is playing when it's actually the expected track. The title-based fallback matching provides a more robust way to identify when the correct track is playing, addressing issue #267.