### PR TITLE
adding queue functionality

### DIFF
--- a/src/app/_components/TrackOptions.tsx
+++ b/src/app/_components/TrackOptions.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 import { api } from "~/trpc/react";
 import { ConfirmationDialog } from "./ConfirmationDialog";
 import { PlaylistSelector } from "./forms/PlaylistSelector";
+import { useMusicPlayerStore } from "./player/MusicPlayerStore";
 import type { PlaylistTrack } from "./player/types/player";
 
 export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
@@ -31,6 +32,7 @@ export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [selectedPlaylists, setSelectedPlaylists] = useState<number[]>([]);
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
+  const enqueueTrack = useMusicPlayerStore((s) => s.enqueueTrack);
 
   const { data: trackPlaylists } = api.tracks.getTrackPlaylists.useQuery(
     {
@@ -102,6 +104,14 @@ export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
         <DropdownMenuContent className="p-2">
           <DropdownMenuItem onClick={() => setOpen(true)}>
             edit song
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => {
+              enqueueTrack(song);
+              toast.success("Song added to queue");
+            }}
+          >
+            add to queue
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => setConfirmationDialogOpen(true)}

--- a/src/app/_components/player/MusicPlayerStore.ts
+++ b/src/app/_components/player/MusicPlayerStore.ts
@@ -15,11 +15,14 @@ interface MusicPlayerState {
   originalPlaylist: PlaylistTrack[] | null;
   currentPlaylistId: number | null;
   currentTrackIndex: number;
+  currentTrack: PlaylistTrack | null;
+  queue: PlaylistTrack[] | null;
 
   // player state
   isShuffleOn: boolean;
   isPlaying: boolean;
   isLoaded: boolean;
+  isPlayingFromQueue: boolean;
   volume: number;
   duration: number;
   currentTime: number;
@@ -48,6 +51,10 @@ interface MusicPlayerState {
   setLoadedOnce: (loadedOnce: boolean) => void;
   setController: (controller: AudioController) => void;
   setPreInitializedSpotifyAdapter: (adapter: SpotifyAdapter | null) => void;
+  setCurrentTrack: (track: PlaylistTrack) => void;
+  enqueueTrack: (track: PlaylistTrack) => void;
+  dequeueTrack: () => PlaylistTrack | null;
+  setIsPlayingFromQueue: (isPlayingFromQueue: boolean) => void;
 }
 
 export const useMusicPlayerStore = create<MusicPlayerState>()(
@@ -57,9 +64,12 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
       originalPlaylist: null,
       currentPlaylistId: null,
       currentTrackIndex: 0,
+      queue: null,
+      currentTrack: null,
       isShuffleOn: false,
       isPlaying: false,
       isLoaded: false,
+      isPlayingFromQueue: false,
       volume: 100,
       duration: 0,
       currentTime: 0,
@@ -73,22 +83,36 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
         playlistId: number,
         options?: setPlaylistOptions,
       ) =>
-        set(() => {
+        set((state) => {
           const { preservePlaybackState = false, newTrackIndex } =
             options ?? {};
+
+          const currentTrackIndex = newTrackIndex ?? 0;
+          const row = playlist[currentTrackIndex] ?? null;
+
+          const playbackReset = preservePlaybackState
+            ? {}
+            : {
+                currentTime: 0,
+                duration: 0,
+                isLoaded: false,
+                isPlaying: false,
+                isPlayingFromQueue: false,
+              };
+
+          const currentTrackUpdate =
+            preservePlaybackState && state.isPlayingFromQueue
+              ? {}
+              : {
+                  currentTrack: row,
+                };
 
           return {
             currentPlaylist: playlist,
             currentPlaylistId: playlistId,
-            currentTrackIndex: newTrackIndex ?? 0,
-            ...(preservePlaybackState
-              ? {}
-              : {
-                  currentTime: 0,
-                  duration: 0,
-                  isLoaded: false,
-                  isPlaying: false,
-                }),
+            currentTrackIndex,
+            ...playbackReset,
+            ...currentTrackUpdate,
           };
         }),
 
@@ -99,6 +123,8 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
       setIsShuffleOn: (isShuffleOn: boolean) => set({ isShuffleOn }),
       setIsPlaying: (playing: boolean) => set({ isPlaying: playing }),
       setIsLoaded: (loaded: boolean) => set({ isLoaded: loaded }),
+      setIsPlayingFromQueue: (isPlayingFromQueue: boolean) =>
+        set({ isPlayingFromQueue }),
       setVolume: (volume: number) => set({ volume }),
       setDuration: (duration: number) => set({ duration }),
       setCurrentTime: (time: number) => set({ currentTime: time }),
@@ -107,6 +133,20 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
       setController: (controller: AudioController) => set({ controller }),
       setPreInitializedSpotifyAdapter: (adapter: SpotifyAdapter) =>
         set({ preInitializedSpotifyAdapter: adapter }),
+      setCurrentTrack: (track: PlaylistTrack) => set({ currentTrack: track }),
+      enqueueTrack: (track: PlaylistTrack) =>
+        set((state) => ({ queue: [...(state.queue ?? []), track] })),
+      dequeueTrack: () => {
+        let next: PlaylistTrack | null = null;
+        set((state) => {
+          if (!state.queue?.length) return state;
+          next = state.queue[0] ?? null;
+          return {
+            queue: state.queue.length === 1 ? null : state.queue.slice(1),
+          };
+        });
+        return next;
+      },
     }),
     {
       name: "music-player-store",
@@ -118,12 +158,14 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
 export const useMusicPlayerComputed = () => {
   const currentPlaylist = useMusicPlayerStore((s) => s.currentPlaylist);
   const currentTrackIndex = useMusicPlayerStore((s) => s.currentTrackIndex);
+  const queue = useMusicPlayerStore((s) => s.queue);
+  const isPlayingFromQueue = useMusicPlayerStore((s) => s.isPlayingFromQueue);
 
   return {
-    currentTrack: currentPlaylist?.[currentTrackIndex] ?? null,
     hasNextTrack: currentPlaylist
-      ? currentTrackIndex < currentPlaylist.length - 1
+      ? currentTrackIndex < currentPlaylist.length - 1 ||
+        (queue && queue.length > 0)
       : false,
-    hasPreviousTrack: currentTrackIndex > 0,
+    hasPreviousTrack: currentTrackIndex > 0 || isPlayingFromQueue,
   };
 };

--- a/src/app/_components/player/adapters/SpotifyAdapter.ts
+++ b/src/app/_components/player/adapters/SpotifyAdapter.ts
@@ -138,11 +138,9 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
         player.addListener("player_state_changed", async (data) => {
           if (data === null) return;
 
-          const { currentPlaylist, currentTrackIndex } =
-            useMusicPlayerStore.getState();
-          const expectedTrack = currentPlaylist?.[currentTrackIndex];
-          const expectedId = expectedTrack?.sourceId ?? null;
-          const expectedTitle = expectedTrack?.title ?? null;
+          const { currentTrack } = useMusicPlayerStore.getState();
+          const expectedId = currentTrack?.sourceId ?? null;
+          const expectedTitle = currentTrack?.title ?? null;
 
           const currentId = data.track_window?.current_track?.id ?? null;
           const currentTitle = data.track_window?.current_track?.name ?? null;
@@ -343,9 +341,8 @@ export class SpotifyAdapter implements MusicPlayerAdapter {
       if (current?.id === trackId) {
         return;
       }
-      const { currentPlaylist, currentTrackIndex } =
-        useMusicPlayerStore.getState();
-      const expectedTitle = currentPlaylist?.[currentTrackIndex]?.title;
+      const { currentTrack } = useMusicPlayerStore.getState();
+      const expectedTitle = currentTrack?.title;
       if (
         expectedTitle?.trim() &&
         current?.name?.trim() &&

--- a/src/app/_components/player/components/desktop/MusicPlayer.tsx
+++ b/src/app/_components/player/components/desktop/MusicPlayer.tsx
@@ -6,7 +6,7 @@ import {
   ArrowsPointingOutIcon,
 } from "@heroicons/react/24/solid";
 import { useState } from "react";
-import { useMusicPlayerComputed } from "~/app/_components/player/MusicPlayerStore";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 import { Button } from "~/components/ui/button";
 import {
   handleProgressChange,
@@ -26,7 +26,7 @@ import { Time } from "./Time";
 import { VolumeControl } from "./VolumeControl";
 
 export const MusicPlayer = () => {
-  const { currentTrack } = useMusicPlayerComputed();
+  const currentTrack = useMusicPlayerStore((s) => s.currentTrack);
   const { isSignedIn } = useUser();
   const [isExpanded, setIsExpanded] = useState(false);
 

--- a/src/app/_components/player/components/mobile/PlayerCard.tsx
+++ b/src/app/_components/player/components/mobile/PlayerCard.tsx
@@ -4,10 +4,7 @@ import { PauseIcon, PlayIcon } from "@heroicons/react/24/solid";
 import { useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { pause, play } from "~/app/_components/player/musicPlayerActions";
-import {
-  useMusicPlayerComputed,
-  useMusicPlayerStore,
-} from "~/app/_components/player/MusicPlayerStore";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
 import { Progress } from "~/components/ui/progress";
@@ -26,7 +23,7 @@ export const PlayerCard = () => {
       })),
     );
 
-  const { currentTrack } = useMusicPlayerComputed();
+  const currentTrack = useMusicPlayerStore((s) => s.currentTrack);
 
   if (!loadedOnce) return null;
 

--- a/src/app/_components/player/components/mobile/PlayerSheet.tsx
+++ b/src/app/_components/player/components/mobile/PlayerSheet.tsx
@@ -33,8 +33,8 @@ export const PlayerSheet = ({
   const isPlaying = useMusicPlayerStore((s) => s.isPlaying);
   const isShuffleOn = useMusicPlayerStore((s) => s.isShuffleOn);
   const currentPlaylist = useMusicPlayerStore((s) => s.currentPlaylist);
-
-  const { currentTrack, hasNextTrack } = useMusicPlayerComputed();
+  const currentTrack = useMusicPlayerStore((s) => s.currentTrack);
+  const { hasNextTrack } = useMusicPlayerComputed();
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange} direction="bottom">

--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -72,6 +72,8 @@ export const previous = async (): Promise<void> => {
     setCurrentTime,
     setCurrentTrackIndex,
     setDuration,
+    isPlayingFromQueue,
+    setIsPlayingFromQueue,
   } = useMusicPlayerStore.getState();
 
   const hasPreviousTrack = currentTrackIndex > 0;
@@ -82,6 +84,15 @@ export const previous = async (): Promise<void> => {
     if (currentTime > 3) {
       await controller.seekTo(0);
       setCurrentTime(0);
+      return;
+    }
+
+    setIsPlayingFromQueue(false);
+    if (isPlayingFromQueue) {
+      setCurrentTime(0);
+      setDuration(0);
+
+      await play();
       return;
     }
 
@@ -104,7 +115,15 @@ export const next = async (): Promise<void> => {
     setCurrentTime,
     setCurrentTrackIndex,
     setDuration,
+    queue,
+    setIsPlayingFromQueue,
   } = useMusicPlayerStore.getState();
+  setIsPlayingFromQueue(false);
+
+  if (queue && queue.length > 0) {
+    await playFromQueue();
+    return;
+  }
 
   const hasNextTrack = currentPlaylist
     ? currentTrackIndex < currentPlaylist.length - 1
@@ -132,6 +151,7 @@ export const play = async (): Promise<void> => {
     setDuration,
     setCurrentTime,
     volume,
+    setCurrentTrack,
   } = useMusicPlayerStore.getState();
 
   setLoadedOnce(true); // show the player on the app for the rest of the time
@@ -146,6 +166,8 @@ export const play = async (): Promise<void> => {
     console.warn("No current track");
     return;
   }
+
+  setCurrentTrack(currentTrack);
 
   // https://developer.spotify.com/documentation/web-playback-sdk/reference#spotifyplayeractivateelement
   if (currentTrack.source === "spotify") {
@@ -212,6 +234,44 @@ export const play = async (): Promise<void> => {
   }
 };
 
+export const playFromQueue = async (): Promise<void> => {
+  const {
+    controller,
+    setIsPlaying,
+    setIsLoaded,
+    setCurrentTime,
+    setDuration,
+    volume,
+    setCurrentTrack,
+    setIsPlayingFromQueue,
+    dequeueTrack,
+  } = useMusicPlayerStore.getState();
+
+  if (!controller) {
+    return;
+  }
+
+  await controller.pause();
+  pauseAnchorAudio();
+  setIsPlaying(false);
+  setIsPlayingFromQueue(true);
+
+  const trackToPlay = dequeueTrack();
+  if (!trackToPlay) {
+    setIsPlayingFromQueue(false);
+    return;
+  }
+  setCurrentTrack(trackToPlay);
+  await controller.loadTrack(trackToPlay);
+
+  setIsLoaded(true);
+  setCurrentTime(0);
+  setDuration(controller.duration);
+
+  await controller.play();
+  await controller.setVolume(volume);
+};
+
 export const handleVolumeChange = async (volume: number[]): Promise<void> => {
   const { controller, setVolume, isLoaded } = useMusicPlayerStore.getState();
 
@@ -250,6 +310,9 @@ export const clearPlayerState = async (): Promise<void> => {
     originalPlaylist: null,
     currentPlaylistId: null,
     currentTrackIndex: 0,
+    currentTrack: null,
+    queue: null,
+    isPlayingFromQueue: false,
     isPlaying: false,
     isLoaded: false,
     isSeeking: false,

--- a/src/app/_components/player/progressTimer.ts
+++ b/src/app/_components/player/progressTimer.ts
@@ -15,6 +15,7 @@ function tick(): void {
     setCurrentTime,
     currentPlaylist,
     currentTrackIndex,
+    queue,
   } = state;
 
   if (!isPlaying || !isLoaded || isSeeking || !controller) return;
@@ -24,7 +25,8 @@ function tick(): void {
 
     if (duration > 0 && time >= duration - 0.5) {
       const hasNextTrack = currentPlaylist
-        ? currentTrackIndex < currentPlaylist.length - 1
+        ? currentTrackIndex < currentPlaylist.length - 1 ||
+          (queue && queue.length > 0)
         : false;
       if (hasNextTrack) {
         void next();

--- a/src/app/artists/ArtistItem.tsx
+++ b/src/app/artists/ArtistItem.tsx
@@ -33,21 +33,18 @@ export const ArtistItem = ({
 }: PlaylistItemProps) => {
   const [hovered, setHovered] = useState(false);
 
-  const { currentPlaylistId, currentTrackIndex, currentPlaylist, isShuffleOn } =
-    useMusicPlayerStore(
-      useShallow((s) => ({
-        currentPlaylistId: s.currentPlaylistId,
-        currentTrackIndex: s.currentTrackIndex,
-        currentPlaylist: s.currentPlaylist,
-        isShuffleOn: s.isShuffleOn,
-      })),
-    );
+  const { currentPlaylistId, currentTrack, isShuffleOn } = useMusicPlayerStore(
+    useShallow((s) => ({
+      currentPlaylistId: s.currentPlaylistId,
+      currentTrack: s.currentTrack,
+      isShuffleOn: s.isShuffleOn,
+    })),
+  );
   const { setCurrentPlaylist, setCurrentTrackIndex, setOriginalPlaylist } =
     useMusicPlayerStore.getState();
 
   const isCurrentTrack =
-    currentPlaylistId === playlistId &&
-    currentPlaylist![currentTrackIndex]!.trackId === trackId;
+    currentPlaylistId === playlistId && currentTrack?.trackId === trackId;
 
   const handlePlay = async () => {
     setCurrentPlaylist(playlist, playlistId);

--- a/src/app/library/components/DataTablePlay.tsx
+++ b/src/app/library/components/DataTablePlay.tsx
@@ -4,26 +4,26 @@ import Lottie from "lottie-react";
 import { Play } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { play } from "~/app/_components/player/musicPlayerActions";
-import {
-  useMusicPlayerComputed,
-  useMusicPlayerStore,
-} from "~/app/_components/player/MusicPlayerStore";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 import SoundWave from "~/app/playlist/[id]/SoundWave.json";
 import { Button } from "~/components/ui/button";
 import { LIBRARY_PLAYLIST_ID } from "~/lib/constants";
 import type { LibraryTrack } from "../DataTable";
 
 export const DataTablePlay = ({ song }: { song: LibraryTrack }) => {
-  const { currentPlaylistId, setCurrentPlaylist, setCurrentTrackIndex } =
-    useMusicPlayerStore(
-      useShallow((s) => ({
-        currentPlaylistId: s.currentPlaylistId,
-        setCurrentPlaylist: s.setCurrentPlaylist,
-        setCurrentTrackIndex: s.setCurrentTrackIndex,
-      })),
-    );
-
-  const { currentTrack } = useMusicPlayerComputed();
+  const {
+    currentPlaylistId,
+    setCurrentPlaylist,
+    setCurrentTrackIndex,
+    currentTrack,
+  } = useMusicPlayerStore(
+    useShallow((s) => ({
+      currentPlaylistId: s.currentPlaylistId,
+      setCurrentPlaylist: s.setCurrentPlaylist,
+      setCurrentTrackIndex: s.setCurrentTrackIndex,
+      currentTrack: s.currentTrack,
+    })),
+  );
 
   const isCurrentTrack =
     currentPlaylistId === LIBRARY_PLAYLIST_ID &&

--- a/src/app/playlist/[id]/ArtworkDisplay.tsx
+++ b/src/app/playlist/[id]/ArtworkDisplay.tsx
@@ -2,10 +2,9 @@
 import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
 
 export const ArtworkDisplay = () => {
-  const currentPlaylist = useMusicPlayerStore((s) => s.currentPlaylist);
-  const currentTrackIndex = useMusicPlayerStore((s) => s.currentTrackIndex);
+  const currentTrack = useMusicPlayerStore((s) => s.currentTrack);
 
-  const artworkUrl = currentPlaylist?.[currentTrackIndex]?.artworkUrl;
+  const artworkUrl = currentTrack?.artworkUrl;
   return (
     <div className="aspect-square w-full">
       {artworkUrl ? (

--- a/src/app/playlist/[id]/PlaylistItem.tsx
+++ b/src/app/playlist/[id]/PlaylistItem.tsx
@@ -28,21 +28,18 @@ export const PlaylistItem = ({
   playlistId,
   trackId,
 }: PlaylistItemProps) => {
-  const { currentPlaylistId, currentTrackIndex, currentPlaylist, isShuffleOn } =
-    useMusicPlayerStore(
-      useShallow((s) => ({
-        currentPlaylistId: s.currentPlaylistId,
-        currentTrackIndex: s.currentTrackIndex,
-        currentPlaylist: s.currentPlaylist,
-        isShuffleOn: s.isShuffleOn,
-      })),
-    );
+  const { currentPlaylistId, isShuffleOn, currentTrack } = useMusicPlayerStore(
+    useShallow((s) => ({
+      currentPlaylistId: s.currentPlaylistId,
+      isShuffleOn: s.isShuffleOn,
+      currentTrack: s.currentTrack,
+    })),
+  );
   const { setCurrentPlaylist, setCurrentTrackIndex, setOriginalPlaylist } =
     useMusicPlayerStore.getState();
 
   const isCurrentTrack =
-    currentPlaylistId === playlistId &&
-    currentPlaylist![currentTrackIndex]!.trackId === trackId;
+    currentPlaylistId === playlistId && currentTrack?.trackId === trackId;
 
   const handlePlay = async () => {
     setCurrentPlaylist(playlist, playlistId);


### PR DESCRIPTION
### TL;DR

Adds a queue system to the music player, allowing users to enqueue tracks and have them play after the current track.

### What changed?

- Added an "add to queue" option in the `TrackOptions` dropdown menu that enqueues a track and shows a toast confirmation.
- Introduced `queue`, `currentTrack`, and `isPlayingFromQueue` state fields to the music player store, along with corresponding actions: `enqueueTrack`, `dequeueTrack`, `setCurrentTrack`, and `setIsPlayingFromQueue`.
- Added a `playFromQueue` action that dequeues the next track and plays it immediately, pausing the current playback first.
- Updated the `next` action to check the queue before advancing to the next playlist track, and updated the `previous` action to return to the current playlist track when navigating back from a queued track.
- Replaced derived `currentTrack` computation (via `currentPlaylist[currentTrackIndex]`) with a dedicated `currentTrack` store field across all components and adapters, simplifying how the active track is accessed.
- Updated `hasNextTrack` and `hasPreviousTrack` computed values to account for queue state.
- The progress timer now triggers `next` when a queued track finishes, enabling seamless queue playback.
- `clearPlayerState` now resets `currentTrack`, `queue`, and `isPlayingFromQueue`.

### How to test?

1. Start playing any track from a playlist.
2. Right-click or open the options menu on another track and select "add to queue." Confirm the toast appears.
3. Let the current track finish or skip forward — the queued track should play next.
4. After the queued track plays, pressing previous should return to the original playlist track rather than going further back.
5. Add multiple tracks to the queue and verify they play in the order they were enqueued.
6. Verify that skipping past the last track in a playlist still plays queued tracks if any are present.

### Why make this change?

Users previously had no way to line up tracks to play next without modifying a playlist. The queue feature provides a lightweight, session-based way to control upcoming playback without altering any saved playlist order.