### PR TITLE
queue added

### DIFF
--- a/src/app/_components/TrackOptions.tsx
+++ b/src/app/_components/TrackOptions.tsx
@@ -105,12 +105,7 @@ export const TrackOptions = ({ song }: { song: PlaylistTrack }) => {
           <DropdownMenuItem onClick={() => setOpen(true)}>
             edit song
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() => {
-              enqueueTrack(song);
-              toast.success("Song added to queue");
-            }}
-          >
+          <DropdownMenuItem onClick={() => enqueueTrack(song)}>
             add to queue
           </DropdownMenuItem>
           <DropdownMenuItem

--- a/src/app/_components/player/MusicPlayerStore.ts
+++ b/src/app/_components/player/MusicPlayerStore.ts
@@ -54,6 +54,8 @@ interface MusicPlayerState {
   setCurrentTrack: (track: PlaylistTrack) => void;
   enqueueTrack: (track: PlaylistTrack) => void;
   dequeueTrack: () => PlaylistTrack | null;
+  clearQueue: () => void;
+  removeQueueItemAt: (index: number) => void;
   setIsPlayingFromQueue: (isPlayingFromQueue: boolean) => void;
 }
 
@@ -147,6 +149,14 @@ export const useMusicPlayerStore = create<MusicPlayerState>()(
         });
         return next;
       },
+      clearQueue: () => set({ queue: null }),
+      removeQueueItemAt: (index: number) =>
+        set((state) => {
+          if (!state.queue?.length) return state;
+          if (index < 0 || index >= state.queue.length) return state;
+          const next = state.queue.filter((_, i) => i !== index);
+          return { queue: next.length > 0 ? next : null };
+        }),
     }),
     {
       name: "music-player-store",

--- a/src/app/_components/player/components/desktop/MusicPlayer.tsx
+++ b/src/app/_components/player/components/desktop/MusicPlayer.tsx
@@ -7,6 +7,7 @@ import {
 } from "@heroicons/react/24/solid";
 import { useState } from "react";
 import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
+import { Queue } from "~/app/_components/queue/Queue";
 import { Button } from "~/components/ui/button";
 import {
   handleProgressChange,
@@ -66,6 +67,8 @@ export const MusicPlayer = () => {
             <Next onNext={next} />
             <span className="text-muted-foreground text-xs">/</span>
             <Shuffle />
+            <span className="text-muted-foreground text-xs">/</span>
+            <Queue direction="right" />
             <span className="text-muted-foreground text-xs">/</span>
             <Button
               variant="ghost"

--- a/src/app/_components/player/components/mobile/PlayerSheet.tsx
+++ b/src/app/_components/player/components/mobile/PlayerSheet.tsx
@@ -19,6 +19,7 @@ import {
   useMusicPlayerComputed,
   useMusicPlayerStore,
 } from "~/app/_components/player/MusicPlayerStore";
+import { Queue } from "~/app/_components/queue/Queue";
 import { Button } from "~/components/ui/button";
 import { Drawer, DrawerContent, DrawerTitle } from "~/components/ui/drawer";
 import { Time } from "../desktop/Time";
@@ -54,13 +55,16 @@ export const PlayerSheet = ({
                   .join(", ")}
               </p>
             </div>
-            <Button
-              variant="ghost"
-              onClick={toggleShuffle}
-              className={isShuffleOn ? "text-amber-600" : "text-primary"}
-            >
-              <ArrowsCrossingIcon className="size-5" />
-            </Button>
+            <div className="flex shrink-0 items-center gap-1">
+              <Queue direction="bottom" />
+              <Button
+                variant="ghost"
+                onClick={toggleShuffle}
+                className={isShuffleOn ? "text-amber-600" : "text-primary"}
+              >
+                <ArrowsCrossingIcon className="size-5" />
+              </Button>
+            </div>
           </div>
           <div className="align-center flex justify-between">
             <Button

--- a/src/app/_components/queue/Queue.tsx
+++ b/src/app/_components/queue/Queue.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { MinusIcon, QueueListIcon } from "@heroicons/react/24/solid";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
+import { Button } from "~/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "~/components/ui/drawer";
+
+type QueueDrawerDirection = "bottom" | "right";
+
+export const Queue = ({ direction }: { direction: QueueDrawerDirection }) => {
+  const queue = useMusicPlayerStore((s) => s.queue);
+  const clearQueue = useMusicPlayerStore((s) => s.clearQueue);
+  const removeQueueItemAt = useMusicPlayerStore((s) => s.removeQueueItemAt);
+
+  const tracks = queue ?? [];
+  const hasItems = tracks.length > 0;
+
+  return (
+    <Drawer direction={direction}>
+      <DrawerTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          aria-label="Open queue"
+          className="h-4 p-0!"
+        >
+          <QueueListIcon
+            className={direction === "right" ? "size-4" : "size-5"}
+            fill="#fff"
+          />
+        </Button>
+      </DrawerTrigger>
+      <DrawerContent className="flex h-[50vh] flex-col md:h-auto">
+        <div className="hidden">
+          <DrawerTitle>queue</DrawerTitle>
+        </div>
+        <DrawerHeader className="border-border shrink-0 border-b pb-3 text-left">
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-semibold">queue</span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="rounded-none text-xs"
+              disabled={!hasItems}
+              onClick={() => clearQueue()}
+            >
+              clear
+            </Button>
+          </div>
+        </DrawerHeader>
+        <div className="flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto overscroll-contain px-4 pb-6">
+          {!hasItems ? (
+            <p className="text-muted-foreground py-6 text-center text-sm">
+              nothing queued
+            </p>
+          ) : (
+            <ul className="flex flex-col divide-y">
+              {tracks.map((track, index) => (
+                <li
+                  key={`${track.trackId}-${index}`}
+                  className="flex items-start gap-2 py-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="line-clamp-2 text-sm">{track.title}</p>
+                    <p className="text-muted-foreground line-clamp-2 text-sm">
+                      {track.artists
+                        .map((artist) => artist.artistName)
+                        .join(", ")}
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground hover:text-destructive size-8 shrink-0"
+                    aria-label={`Remove ${track.title} from queue`}
+                    onClick={() => removeQueueItemAt(index)}
+                  >
+                    <MinusIcon className="size-4" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+};


### PR DESCRIPTION
### TL;DR

Adds a queue viewer that lets users see, remove individual tracks from, and clear the playback queue.

### What changed?

- Added a `Queue` drawer component that displays the current playback queue, with support for opening from the bottom (mobile) or right (desktop)
- Added `clearQueue` and `removeQueueItemAt` actions to the music player store
- Integrated the `Queue` component into both the desktop `MusicPlayer` and mobile `PlayerSheet`
- Removed the inline `toast.success` call from the "add to queue" dropdown item in `TrackOptions`

### How to test?

1. Add one or more songs to the queue via the track options menu
2. Open the queue drawer using the queue icon in the player (desktop or mobile)
3. Verify all queued tracks appear in the list
4. Remove an individual track using the minus button and confirm it disappears from the list
5. Use the "clear" button to remove all tracks and confirm the empty state message appears
6. Confirm the "clear" button is disabled when the queue is empty

### Why make this change?

Previously there was no way to inspect or manage the playback queue after adding songs to it. This gives users visibility into what's queued and control over the queue without having to navigate away from the player.