### PR TITLE
command search added

### DIFF
--- a/src/app/_components/ConfirmationDialog.tsx
+++ b/src/app/_components/ConfirmationDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogContent,
   DialogFooter,
   DialogHeader,
+  DialogTitle,
 } from "~/components/ui/dialog";
 
 export const ConfirmationDialog = ({
@@ -21,6 +22,9 @@ export const ConfirmationDialog = ({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
+        <div className="hidden">
+          <DialogTitle>Confirmation: {text}</DialogTitle>
+        </div>
         <DialogHeader className="pt-3 sm:text-center">{text}</DialogHeader>
         <DialogFooter className="sm:justify-center">
           <DialogClose asChild>

--- a/src/app/_components/nav/MobileNavDrawer.tsx
+++ b/src/app/_components/nav/MobileNavDrawer.tsx
@@ -45,7 +45,7 @@ export const GlobalMobileNavDrawer = () => {
     <>
       <Drawer open={open} onOpenChange={setOpen} direction="top">
         <DrawerTrigger asChild className="md:hidden">
-          <div className="flex justify-end px-3 pt-1 md:hidden">
+          <div className="md:hidden">
             <Button
               variant="ghost"
               size="icon"

--- a/src/app/_components/search/LibrarySearchCommand.tsx
+++ b/src/app/_components/search/LibrarySearchCommand.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useUser } from "@clerk/nextjs";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
+import { Ellipsis } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { play } from "~/app/_components/player/musicPlayerActions";
+import { useMusicPlayerStore } from "~/app/_components/player/MusicPlayerStore";
+import type { LibraryTrack } from "~/app/library/DataTable";
+import { Button } from "~/components/ui/button";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "~/components/ui/command";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+import { LIBRARY_PLAYLIST_ID } from "~/lib/constants";
+import { api } from "~/trpc/react";
+
+function isEditableElement(node: EventTarget | null): boolean {
+  if (!node || !(node instanceof HTMLElement)) return false;
+  if (node.isContentEditable) return true;
+  return node.closest("input, textarea, select") != null;
+}
+
+async function playLibraryTrack(song: LibraryTrack) {
+  const {
+    currentPlaylistId,
+    setCurrentPlaylist,
+    setCurrentTrackIndex,
+    currentTrack,
+  } = useMusicPlayerStore.getState();
+
+  if (
+    currentPlaylistId !== LIBRARY_PLAYLIST_ID ||
+    currentTrack?.trackId !== song.trackId
+  ) {
+    setCurrentPlaylist([song], LIBRARY_PLAYLIST_ID);
+  }
+  setCurrentTrackIndex(0);
+  await play();
+}
+
+export function LibrarySearchCommand() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const { isSignedIn } = useUser();
+
+  useEffect(() => {
+    const id = window.setTimeout(() => setDebouncedSearch(search), 250);
+    return () => window.clearTimeout(id);
+  }, [search]);
+
+  const trimmedDebounced = debouncedSearch.trim();
+  const { data, isPending } = api.library.search.useQuery(
+    { query: debouncedSearch },
+    { enabled: open && trimmedDebounced.length > 0 },
+  );
+
+  const handleOpenChange = useCallback((next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      setSearch("");
+      setDebouncedSearch("");
+    }
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.key.toLowerCase() !== "k") return;
+      if (!open && isEditableElement(e.target)) return;
+      e.preventDefault();
+      setOpen((prev) => {
+        if (prev) {
+          setSearch("");
+          setDebouncedSearch("");
+          return false;
+        }
+        setSearch("");
+        setDebouncedSearch("");
+        return true;
+      });
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  const artists = data?.artists ?? [];
+  const songs = data?.songs ?? [];
+  const hasQuery = trimmedDebounced.length > 0;
+  const showEmpty =
+    hasQuery && !isPending && artists.length === 0 && songs.length === 0;
+
+  if (!isSignedIn) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="md:hidden"
+        onClick={() => setOpen(true)}
+      >
+        <MagnifyingGlassIcon className="size-4" />
+      </Button>
+      <CommandDialog
+        open={open}
+        onOpenChange={handleOpenChange}
+        title="Search library"
+        description="Search artists and songs in your library"
+        shouldFilter={false}
+      >
+        <CommandInput
+          placeholder="Search artists and songs…"
+          value={search}
+          onValueChange={setSearch}
+        />
+        <CommandList>
+          {!hasQuery && (
+            <div className="text-muted-foreground py-6 text-center text-sm">
+              Type to search your library. Press ⌘K or Ctrl+K to toggle.
+            </div>
+          )}
+          {hasQuery && isPending && (
+            <div className="text-muted-foreground py-6 text-center text-sm">
+              Searching…
+            </div>
+          )}
+          {showEmpty && <CommandEmpty>No results found.</CommandEmpty>}
+          {!isPending && artists.length > 0 && (
+            <CommandGroup heading="Artists">
+              {artists.map((artist) => (
+                <CommandItem
+                  key={artist.id}
+                  value={`artist-${artist.id}`}
+                  onSelect={() => {
+                    router.push(`/artists/${artist.id}`);
+                    handleOpenChange(false);
+                  }}
+                >
+                  {artist.name}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+          {!isPending && artists.length > 0 && songs.length > 0 && (
+            <CommandSeparator />
+          )}
+          {!isPending && songs.length > 0 && (
+            <CommandGroup heading="Songs">
+              {songs.map((song) => (
+                <CommandItem
+                  key={song.trackId}
+                  value={`song-${song.trackId}`}
+                  className="flex items-center gap-2 pr-1"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-medium">{song.title}</div>
+                    <div className="text-muted-foreground truncate text-xs">
+                      {song.artists.map((a) => a.artistName).join(", ")}
+                    </div>
+                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground pointer-events-auto size-8 shrink-0"
+                        aria-label={`Options for ${song.title}`}
+                        onClick={(e) => e.stopPropagation()}
+                        onPointerDown={(e) => {
+                          e.stopPropagation();
+                        }}
+                      >
+                        <Ellipsis className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="end"
+                      onCloseAutoFocus={(e) => e.preventDefault()}
+                    >
+                      <DropdownMenuItem
+                        onClick={async () => {
+                          await playLibraryTrack(song);
+                          handleOpenChange(false);
+                        }}
+                      >
+                        Play
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => {
+                          useMusicPlayerStore.getState().enqueueTrack(song);
+                          handleOpenChange(false);
+                        }}
+                      >
+                        Add to queue
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { GlobalMobileNavDrawer } from "~/app/_components/nav/MobileNavDrawer";
 import { MusicPlayer } from "~/app/_components/player/components/desktop/MusicPlayer";
 import { AppMediaAnchor } from "~/app/_components/player/components/MediaSessionAnchor";
 import { PlayerCard } from "~/app/_components/player/components/mobile/PlayerCard";
+import { LibrarySearchCommand } from "~/app/_components/search/LibrarySearchCommand";
 import { Toaster } from "~/components/ui/sonner";
 import { TRPCReactProvider } from "~/trpc/react";
 
@@ -33,7 +34,8 @@ export default function RootLayout({
           <TRPCReactProvider>
             <GlobalContextMenu>
               <div className="flex h-dvh min-h-0 flex-col overflow-hidden">
-                <div className="shrink-0">
+                <div className="flex shrink-0 items-center justify-end gap-1 pt-1 pr-2 md:hidden">
+                  <LibrarySearchCommand />
                   <GlobalMobileNavDrawer />
                 </div>
                 <div className="hidden shrink-0 md:block">

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ function Command({
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
         className
       )}
       {...props}
@@ -35,12 +35,14 @@ function CommandDialog({
   children,
   className,
   showCloseButton = true,
+  shouldFilter = true,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
   title?: string
   description?: string
   className?: string
   showCloseButton?: boolean
+  shouldFilter?: boolean
 }) {
   return (
     <Dialog {...props}>
@@ -52,7 +54,10 @@ function CommandDialog({
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          shouldFilter={shouldFilter}
+          className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+        >
           {children}
         </Command>
       </DialogContent>
@@ -73,7 +78,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}
@@ -118,7 +123,7 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
         className
       )}
       {...props}
@@ -133,7 +138,7 @@ function CommandSeparator({
   return (
     <CommandPrimitive.Separator
       data-slot="command-separator"
-      className={cn("bg-border -mx-1 h-px", className)}
+      className={cn("-mx-1 h-px bg-border", className)}
       {...props}
     />
   )
@@ -147,7 +152,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}
@@ -163,7 +168,7 @@ function CommandShortcut({
     <span
       data-slot="command-shortcut"
       className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
+        "ml-auto text-xs tracking-widest text-muted-foreground",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
 
 import { cn } from "~/lib/utils"
+import { Button } from "~/components/ui/button"
 
 function Dialog({
   ...props
@@ -38,7 +39,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}
@@ -60,7 +61,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
         {...props}
@@ -69,7 +70,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -90,7 +91,14 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
   return (
     <div
       data-slot="dialog-footer"
@@ -99,7 +107,14 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
         className
       )}
       {...props}
-    />
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
   )
 }
 
@@ -123,7 +138,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
   )

--- a/src/server/api/routers/library.ts
+++ b/src/server/api/routers/library.ts
@@ -1,6 +1,79 @@
+import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 export const libraryRouter = createTRPCRouter({
+  search: protectedProcedure
+    .input(z.object({ query: z.string().max(100) }))
+    .query(async ({ ctx, input }) => {
+      const trimmed = input.query.trim();
+      if (!trimmed) {
+        return { artists: [] as { id: number; name: string }[], songs: [] };
+      }
+
+      const artistWhere = {
+        userId: ctx.user.id,
+        name: { contains: trimmed, mode: "insensitive" as const },
+        libraryTracks: {
+          some: {
+            libraryTrack: {
+              userId: ctx.user.id,
+            },
+          },
+        },
+      };
+
+      const [artists, libraryTracks] = await Promise.all([
+        ctx.db.artist.findMany({
+          where: artistWhere,
+          take: 3,
+          orderBy: { name: "asc" },
+          select: { id: true, name: true },
+        }),
+        ctx.db.libraryTrack.findMany({
+          where: {
+            userId: ctx.user.id,
+            title: { contains: trimmed, mode: "insensitive" },
+          },
+          take: 5,
+          orderBy: { title: "asc" },
+          include: {
+            track: true,
+            artists: {
+              include: {
+                artist: true,
+              },
+            },
+            album: true,
+            playlistEntries: true,
+          },
+        }),
+      ]);
+
+      const songs = libraryTracks.map((track) => ({
+        id: track.id,
+        title: track.title,
+        artists: track.artists.map((artist) => ({
+          artistId: artist.artistId,
+          artistName: artist.artist.name,
+        })),
+        album: track.album?.name ?? null,
+        duration: track.track.duration,
+        source: track.track.source,
+        sourceId: track.track.sourceId,
+        sourceUrl: track.track.sourceUrl,
+        artworkUrl: track.track.artworkUrl,
+        trackId: track.id,
+        playlistId: -1,
+        playlistName: "",
+        position: 1,
+        albumId: track.album?.id ?? null,
+        isPlayable: track.track.isPlayable,
+        isInAnyPlaylist: track.playlistEntries.length > 0,
+      }));
+
+      return { artists, songs };
+    }),
+
   getAll: protectedProcedure.query(async ({ ctx }) => {
     const libraryTracks = await ctx.db.libraryTrack.findMany({
       where: {


### PR DESCRIPTION
### TL;DR

Adds a library search command palette accessible via a magnifying glass button on mobile or the ⌘K / Ctrl+K keyboard shortcut.

### What changed?

- Introduced `LibrarySearchCommand`, a new command palette component that lets signed-in users search their library for artists and songs. Results are debounced and fetched via a new `library.search` tRPC endpoint. Artists navigate to their detail page on selection; songs can be played immediately or added to the queue via a dropdown menu.
- Added the `library.search` protected procedure to the library router, querying up to 3 matching artists and 5 matching songs (case-insensitive) from the authenticated user's library.
- Placed `LibrarySearchCommand` alongside `GlobalMobileNavDrawer` in the top mobile header bar, replacing the previous padding-based layout with a flex row.
- Added a hidden `DialogTitle` to `ConfirmationDialog` to satisfy accessibility requirements.
- Exposed a `shouldFilter` prop on `CommandDialog` to allow server-side filtering to be used instead of the default client-side filtering.
- Added an optional `showCloseButton` prop to `DialogFooter` that renders a close button when enabled.
- Migrated `dialog.tsx` to import from `radix-ui` instead of `@radix-ui/react-dialog` and added `outline-none` to `DialogContent`.

### How to test?

1. Sign in and open the app on a mobile viewport.
2. Tap the magnifying glass icon in the top bar — the search command palette should open.
3. Type an artist or song name and verify matching results appear, separated into "Artists" and "Songs" groups.
4. Select an artist to confirm navigation to their page.
5. Use the ellipsis menu on a song result to play it or add it to the queue.
6. On any viewport, press ⌘K or Ctrl+K to toggle the palette open and closed.
7. Confirm the palette does not open via the keyboard shortcut when focus is inside an input or editable element.

### Why make this change?

Users on mobile had no quick way to find and play specific tracks or navigate to artists without scrolling through the full library table. A command palette provides fast, keyboard- and tap-accessible search without leaving the current context.