### PR TITLE
minor stylign fixes

### DIFF
--- a/src/app/_components/player/components/mobile/PlayerCard.tsx
+++ b/src/app/_components/player/components/mobile/PlayerCard.tsx
@@ -33,11 +33,9 @@ export const PlayerCard = () => {
         <Card className="w-full rounded-none p-0" onClick={() => setOpen(true)}>
           <div className="flex h-full flex-col">
             <div className="flex flex-row items-center justify-between px-6 py-3">
-              <div>
-                <p className="line-clamp-1 truncate font-semibold">
-                  {currentTrack?.title}
-                </p>
-                <p className="text-muted-foreground line-clamp-1 truncate text-sm">
+              <div className="min-w-0">
+                <p className="truncate font-semibold">{currentTrack?.title}</p>
+                <p className="text-muted-foreground truncate text-sm">
                   {currentTrack?.artists
                     .map((artist) => artist.artistName)
                     .join(", ")}

--- a/src/app/_components/player/components/mobile/PlayerSheet.tsx
+++ b/src/app/_components/player/components/mobile/PlayerSheet.tsx
@@ -43,13 +43,12 @@ export const PlayerSheet = ({
         <div className="hidden">
           <DrawerTitle>Player</DrawerTitle>
         </div>
+
         <div className="flex flex-col justify-between gap-4 px-4 py-8">
-          <div className="flex items-center justify-between">
-            <div className="flex flex-col">
-              <p className="line-clamp-1 truncate font-semibold">
-                {currentTrack?.title}
-              </p>
-              <p className="text-muted-foreground line-clamp-1 truncate text-sm">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex min-w-0 flex-1 flex-col">
+              <p className="truncate font-semibold">{currentTrack?.title}</p>
+              <p className="text-muted-foreground truncate text-sm">
                 {currentTrack?.artists
                   .map((artist) => artist.artistName)
                   .join(", ")}
@@ -66,6 +65,7 @@ export const PlayerSheet = ({
               </Button>
             </div>
           </div>
+
           <div className="align-center flex justify-between">
             <Button
               variant="ghost"
@@ -93,6 +93,7 @@ export const PlayerSheet = ({
               <ForwardIcon className="size-5" fill="#fff" />
             </Button>
           </div>
+
           <div className="flex flex-col gap-2">
             <Time />
             <ProgressBar

--- a/src/app/playlist/[id]/page.tsx
+++ b/src/app/playlist/[id]/page.tsx
@@ -13,14 +13,14 @@ const Playlist = async ({ params }: { params: Promise<{ id: string }> }) => {
 
   return (
     <div className="grid h-full min-h-0 w-full grid-cols-1 grid-rows-1 p-2 md:grid-cols-[2fr_1fr]">
-      <div className="flex h-full min-h-0 flex-col overflow-hidden pr-4">
+      <div className="flex h-full min-h-0 flex-col overflow-hidden pr-2">
         <div className="shrink-0">
           <PlaylistHeader
             playlistId={playlist.playlistId}
             playlistName={playlist.playlistName}
           />
         </div>
-        <div className="flex min-h-0 flex-1 flex-col items-center gap-4 overflow-y-auto md:gap-2">
+        <div className="flex min-h-0 flex-1 flex-col items-center gap-4 overflow-y-auto [scrollbar-gutter:stable] md:gap-2">
           {playlist.playlistEntries.map((song, index) => {
             return (
               <PlaylistItem


### PR DESCRIPTION
### TL;DR

Some minor css fixes. On `playlist` page, on different platforms the scroll bar would overlay the `trackOptions` ellipsis. Now it has an explicit gutter space.

On mobile, if there was a very long list of artists, in the player they weren't getting truncated properly and displacing other items. 

### What changed?

- Removed redundant `line-clamp-1` classes from track title and artist name text in both `PlayerCard` and `PlayerSheet`, keeping only `truncate` for overflow handling.
- Added `min-w-0` to the track info container in `PlayerCard` to allow proper text truncation within flex layouts.
- Added `min-w-0 flex-1` and `gap-2` to the track info container in `PlayerSheet` to ensure the text area shrinks correctly and doesn't overflow into adjacent buttons.
- Added `[scrollbar-gutter:stable]` to the playlist scroll container to prevent layout shift when the scrollbar appears or disappears.
- Reduced the right padding on the playlist column from `pr-4` to `pr-2`.

### How to test?

1. Open the mobile player with a track that has a long title or multiple artists and verify the text truncates correctly without overflowing into the like/options buttons.
2. Navigate to a playlist with enough songs to trigger a scrollbar and confirm the layout does not shift when scrolling.

### Why make this change?

Text in the mobile player was not truncating properly due to missing `min-w-0` constraints on flex children, causing long titles and artist names to overflow. The `line-clamp-1` was redundant alongside `truncate` and has been removed. The `scrollbar-gutter:stable` addition prevents the playlist content from jumping when a scrollbar becomes visible.