### PR TITLE
resume queue play quick fix

### DIFF
--- a/src/app/_components/player/musicPlayerActions.ts
+++ b/src/app/_components/player/musicPlayerActions.ts
@@ -152,9 +152,16 @@ export const play = async (): Promise<void> => {
     setCurrentTime,
     volume,
     setCurrentTrack,
+    isPlayingFromQueue,
   } = useMusicPlayerStore.getState();
 
   setLoadedOnce(true); // show the player on the app for the rest of the time
+
+  if (isPlayingFromQueue) {
+    await controller?.play();
+    await controller?.setVolume(volume);
+    return;
+  }
 
   if (!currentPlaylist || currentPlaylist.length === 0) {
     console.warn("No playlist loaded");


### PR DESCRIPTION
### TL;DR

Added early return in the `play` function to handle queue playback separately from playlist playback.

### What changed?

When `isPlayingFromQueue` is `true`, the `play` function now immediately invokes `controller?.play()` and sets the volume, then returns early — bypassing the standard playlist logic entirely.

### How to test?

1. Add tracks to the queue and begin playback from the queue.
2. Verify that playback starts correctly and volume is applied.
3. Confirm that the playlist-based playback logic is not triggered when playing from the queue.
4. Ensure normal playlist playback still functions as expected when `isPlayingFromQueue` is `false`.

### Why make this change?

Queue playback requires different handling than playlist playback. Without this early return, the `play` function would fall through to playlist-specific logic, which could cause incorrect behavior or warnings (e.g., "No playlist loaded") when the user is playing tracks from the queue rather than a loaded playlist.